### PR TITLE
Fix the 'for loop' snippet missing index bug.

### DIFF
--- a/snippets/language-c.cson
+++ b/snippets/language-c.cson
@@ -17,7 +17,7 @@
     'body': 'int main (int argc, char const *argv[])\n{\n\t${1:/* code */}\n\treturn 0;\n}'
   'For Loop':
     'prefix': 'for'
-    'body': 'for(size_t ${1:i} = 0; $2 < ${2:count}; ${3:i}++)\n{\n\t${4:/* code */}\n}'
+    'body': 'for(size_t ${1:i} = 0; ${2:i} < ${3:count}; ${4:i}++)\n{\n\t${5:/* code */}\n}'
   'Header Include-Guard':
     'prefix': 'once'
     'body': '#ifndef ${1:SYMBOL}\n#define ${2:SYMBOL}\n\n${3}\n\n#endif /* end of include guard: ${4:SYMBOL} */\n'


### PR DESCRIPTION
In C/C++ file, the 'for' snippet missing the index 'i' after first ';'
![original](https://f.cloud.github.com/assets/956438/2312453/3dfe0346-a2fc-11e3-910f-34d62ac14f87.gif)

After fixed:
![fixed](https://f.cloud.github.com/assets/956438/2312466/66127a88-a2fc-11e3-8380-fc93c1d7b9e7.gif)
