### PR TITLE
Change c++ -> cxx to stop confusing slick

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -23,61 +23,61 @@
   }
   {
     'match': '\\b(friend|explicit|virtual)\\b'
-    'name': 'storage.modifier.c++'
+    'name': 'storage.modifier.cxx'
   }
   {
     'match': '\\b(private:|protected:|public:)'
-    'name': 'storage.modifier.c++'
+    'name': 'storage.modifier.cxx'
   }
   {
     'match': '\\b(catch|operator|try|throw|using)\\b'
-    'name': 'keyword.control.c++'
+    'name': 'keyword.control.cxx'
   }
   {
     'match': '\\bdelete\\b(\\s*\\[\\])?|\\bnew\\b(?!])'
-    'name': 'keyword.control.c++'
+    'name': 'keyword.control.cxx'
   }
   {
     'comment': 'common C++ instance var naming idiom -- fMemberName'
     'match': '\\b(f|m)[A-Z]\\w*\\b'
-    'name': 'variable.other.readwrite.member.c++'
+    'name': 'variable.other.readwrite.member.cxx'
   }
   {
     'match': '\\b(this|nullptr)\\b'
-    'name': 'variable.language.c++'
+    'name': 'variable.language.cxx'
   }
   {
     'match': '\\btemplate\\b\\s*'
-    'name': 'storage.type.template.c++'
+    'name': 'storage.type.template.cxx'
   }
   {
     'match': '\\b(const_cast|dynamic_cast|reinterpret_cast|static_cast)\\b\\s*'
-    'name': 'keyword.operator.cast.c++'
+    'name': 'keyword.operator.cast.cxx'
   }
   {
     'match': '\\b(and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq)\\b'
-    'name': 'keyword.operator.c++'
+    'name': 'keyword.operator.cxx'
   }
   {
     'match': '\\b(class|wchar_t)\\b'
-    'name': 'storage.type.c++'
+    'name': 'storage.type.cxx'
   }
   {
     'match': '\\b(constexpr|export|mutable|typename)\\b'
-    'name': 'storage.modifier.c++'
+    'name': 'storage.modifier.cxx'
   }
   {
     'begin': '(?x)\n    \t\t\t\t(?:  ^                                 # begin-of-line\n    \t\t\t\t  |  (?: (?<!else|new|=) )             #  or word + space before name\n    \t\t\t\t)\n    \t\t\t\t((?:[A-Za-z_][A-Za-z0-9_]*::)*+~[A-Za-z_][A-Za-z0-9_]*) # actual name\n    \t\t\t\t \\s*(\\()                           # start bracket or end-of-line\n    \t\t\t'
     'beginCaptures':
       '1':
-        'name': 'entity.name.function.c++'
+        'name': 'entity.name.function.cxx'
       '2':
         'name': 'punctuation.definition.parameters.begin.c'
     'end': '\\)'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.parameters.end.c'
-    'name': 'meta.function.destructor.c++'
+    'name': 'meta.function.destructor.cxx'
     'patterns': [
       {
         'include': '$base'
@@ -88,14 +88,14 @@
     'begin': '(?x)\n    \t\t\t\t(?:  ^                                 # begin-of-line\n    \t\t\t\t  |  (?: (?<!else|new|=) )             #  or word + space before name\n    \t\t\t\t)\n    \t\t\t\t((?:[A-Za-z_][A-Za-z0-9_]*::)*+~[A-Za-z_][A-Za-z0-9_]*) # actual name\n    \t\t\t\t \\s*(\\()                           # terminating semi-colon\n    \t\t\t'
     'beginCaptures':
       '1':
-        'name': 'entity.name.function.c++'
+        'name': 'entity.name.function.cxx'
       '2':
         'name': 'punctuation.definition.parameters.begin.c'
     'end': '\\)'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.parameters.end.c'
-    'name': 'meta.function.destructor.prototype.c++'
+    'name': 'meta.function.destructor.prototype.cxx'
     'patterns': [
       {
         'include': '$base'
@@ -107,7 +107,7 @@
   'angle_brackets':
     'begin': '<'
     'end': '>'
-    'name': 'meta.angle-brackets.c++'
+    'name': 'meta.angle-brackets.cxx'
     'patterns': [
       {
         'include': '#angle_brackets'
@@ -125,7 +125,7 @@
     'endCaptures':
       '0':
         'name': 'punctuation.section.block.end.c'
-    'name': 'meta.block.c++'
+    'name': 'meta.block.cxx'
     'patterns': [
       {
         'captures':
@@ -146,14 +146,14 @@
         'begin': '(?x)\n    \t\t\t\t(?:  ^\\s*)                             # begin-of-line\n    \t\t\t\t((?!while|for|do|if|else|switch|catch|enumerate|r?iterate)[A-Za-z_][A-Za-z0-9_:]*) # actual name\n    \t\t\t\t \\s*(\\()                            # start bracket or end-of-line\n    \t\t\t'
         'beginCaptures':
           '1':
-            'name': 'entity.name.function.c++'
+            'name': 'entity.name.function.cxx'
           '2':
             'name': 'punctuation.definition.parameters.begin.c'
         'end': '\\)'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.parameters.end.c'
-        'name': 'meta.function.constructor.c++'
+        'name': 'meta.function.constructor.cxx'
         'patterns': [
           {
             'include': '$base'
@@ -166,7 +166,7 @@
           '1':
             'name': 'punctuation.definition.parameters.c'
         'end': '(?=\\{)'
-        'name': 'meta.function.constructor.initializer-list.c++'
+        'name': 'meta.function.constructor.initializer-list.cxx'
         'patterns': [
           {
             'include': '$base'
@@ -180,24 +180,24 @@
         'begin': '\\b(namespace)\\b\\s*([_A-Za-z][_A-Za-z0-9]*\\b)?+'
         'beginCaptures':
           '1':
-            'name': 'storage.type.c++'
+            'name': 'storage.type.cxx'
           '2':
-            'name': 'entity.name.type.c++'
+            'name': 'entity.name.type.cxx'
         'captures':
           '1':
             'name': 'keyword.control.namespace.$2'
         'end': '(?<=\\})|(?=(;|,|\\(|\\)|>|\\[|\\]|=))'
-        'name': 'meta.namespace-block${2:+.$2}.c++'
+        'name': 'meta.namespace-block${2:+.$2}.cxx'
         'patterns': [
           {
             'begin': '\\{'
             'beginCaptures':
               '0':
-                'name': 'punctuation.definition.scope.c++'
+                'name': 'punctuation.definition.scope.cxx'
             'end': '\\}'
             'endCaptures':
               '0':
-                'name': 'punctuation.definition.scope.c++'
+                'name': 'punctuation.definition.scope.cxx'
             'patterns': [
               {
                 'include': '#special_block'
@@ -219,26 +219,26 @@
         'begin': '\\b(class|struct)\\b\\s*([_A-Za-z][_A-Za-z0-9]*\\b)?+(\\s*:\\s*(public|protected|private)\\s*([_A-Za-z][_A-Za-z0-9]*\\b)((\\s*,\\s*(public|protected|private)\\s*[_A-Za-z][_A-Za-z0-9]*\\b)*))?'
         'beginCaptures':
           '1':
-            'name': 'storage.type.c++'
+            'name': 'storage.type.cxx'
           '2':
-            'name': 'entity.name.type.c++'
+            'name': 'entity.name.type.cxx'
           '4':
-            'name': 'storage.type.modifier.c++'
+            'name': 'storage.type.modifier.cxx'
           '5':
-            'name': 'entity.name.type.inherited.c++'
+            'name': 'entity.name.type.inherited.cxx'
           '6':
             'patterns': [
               {
                 'match': '(public|protected|private)'
-                'name': 'storage.type.modifier.c++'
+                'name': 'storage.type.modifier.cxx'
               }
               {
                 'match': '[_A-Za-z][_A-Za-z0-9]*'
-                'name': 'entity.name.type.inherited.c++'
+                'name': 'entity.name.type.inherited.cxx'
               }
             ]
         'end': '(?<=\\})|(?=(;|\\(|\\)|>|\\[|\\]|=))'
-        'name': 'meta.class-struct-block.c++'
+        'name': 'meta.class-struct-block.cxx'
         'patterns': [
           {
             'include': '#angle_brackets'
@@ -247,13 +247,13 @@
             'begin': '\\{'
             'beginCaptures':
               '0':
-                'name': 'punctuation.section.block.begin.c++'
+                'name': 'punctuation.section.block.begin.cxx'
             'end': '(\\})(\\s*\\n)?'
             'endCaptures':
               '1':
-                'name': 'punctuation.definition.invalid.c++'
+                'name': 'punctuation.definition.invalid.cxx'
               '2':
-                'name': 'invalid.illegal.you-forgot-semicolon.c++'
+                'name': 'invalid.illegal.you-forgot-semicolon.cxx'
             'patterns': [
               {
                 'include': '#special_block'
@@ -275,9 +275,9 @@
         'begin': '\\b(extern)(?=\\s*")'
         'beginCaptures':
           '1':
-            'name': 'storage.modifier.c++'
+            'name': 'storage.modifier.cxx'
         'end': '(?<=\\})|(?=\\w)'
-        'name': 'meta.extern-block.c++'
+        'name': 'meta.extern-block.cxx'
         'patterns': [
           {
             'begin': '\\{'
@@ -303,4 +303,4 @@
         ]
       }
     ]
-'scopeName': 'source.c++'
+'scopeName': 'source.cxx'

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -344,26 +344,26 @@
           '1':
             'name': 'meta.toc-list.banner.line.c'
         'match': '^// =(\\s*.*?)\\s*=\\s*$\\n?'
-        'name': 'comment.line.banner.c++'
+        'name': 'comment.line.banner.cxx'
       }
       {
         'begin': '(^[ \\t]+)?(?=//)'
         'beginCaptures':
           '1':
-            'name': 'punctuation.whitespace.comment.leading.c++'
+            'name': 'punctuation.whitespace.comment.leading.cxx'
         'end': '(?!\\G)'
         'patterns': [
           {
             'begin': '//'
             'beginCaptures':
               '0':
-                'name': 'punctuation.definition.comment.c++'
+                'name': 'punctuation.definition.comment.cxx'
             'end': '\\n'
-            'name': 'comment.line.double-slash.c++'
+            'name': 'comment.line.double-slash.cxx'
             'patterns': [
               {
                 'match': '(?>\\\\\\s*\\n)'
-                'name': 'punctuation.separator.continuation.c++'
+                'name': 'punctuation.separator.continuation.cxx'
               }
             ]
           }


### PR DESCRIPTION
Replace c++ with cxx to avoid confusing slick parser (which thinks c++ is something special)
