### PR TITLE
Remove strange term which breaks parser

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -187,7 +187,7 @@
           '1':
             'name': 'keyword.control.namespace.$2'
         'end': '(?<=\\})|(?=(;|,|\\(|\\)|>|\\[|\\]|=))'
-        'name': 'meta.namespace-block${2:+.$2}.c++'
+        'name': 'meta.namespace-block.c++'
         'patterns': [
           {
             'begin': '\\{'


### PR DESCRIPTION
There is a strange piece of code, I'm not sure what it does and I'm sure it doesn't do anything useful. Lets remove it so atom doesn't crash when people type 'namespace'.
