### PR TITLE
Change badly named end of block to improve syntax highlighting

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -251,7 +251,7 @@
             'end': '(\\})(\\s*\\n)?'
             'endCaptures':
               '1':
-                'name': 'punctuation.definition.invalid.c++'
+                'name': 'punctuation.section.block.end.c++'
               '2':
                 'name': 'invalid.illegal.you-forgot-semicolon.c++'
             'patterns': [


### PR DESCRIPTION
In some colouring, the final } in a class is displayed in a bad colour. This is because it has the name 'punctuation.definition.invalid.c++', and the 'invalid' is coloured in a way to mark code bad. I have changed the name to the more reasonable 'punctuation.section.block.end.c++' (to pair with 'punctuation.section.block.begin.c++' just above)

Now some justification :) At first I assumed this rule was supposed to match some kind of invalid construction, particularly because the next match in the rule is 'invalid.illegal.you-forgot-semicolon.c++'. However, on closer inspection (and after comparing the behaviour with sublime text), I believe this rule is always supposed to match the end of classes, but the 'invalid.illegal.you-forgot-semicolon.c++' will match no text (which is fine) if the semicolon is present. sublimetext also attaches 'punctuation.definition.invalid.c++' to the closing } in every C++ class. However, this is a terrible name, so let's change it.
