### PR TITLE
Add support for '.ipp' extension.

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -10,6 +10,7 @@
   'h'
   'hh'
   'hpp'
+  'ipp'
   'h++'
 ]
 'firstLineMatch': '-\\*- C\\+\\+ -\\*-'


### PR DESCRIPTION
`ipp` is commonly used for template implementation files and is found commonly in many libraries, notably boost.
