### PR TITLE
Improve snippets

### DIFF
--- a/snippets/language-c.cson
+++ b/snippets/language-c.cson
@@ -41,6 +41,12 @@
   'Struct':
     'prefix': 'st'
     'body': 'struct ${1:name_t}\n{\n\t${2:/* data */}\n};'
+  'void':
+    'prefix': 'void'
+    'body': 'void ${1:name} (${2:/* arguments */})\n{\n\t${3:/* code */}\n}'
+  'any function':
+    'prefix': 'func'
+    'body': '${1:int} ${2:name} (${3:/* arguments */})\n{\n\t${5:/* code */}\n\treturn ${4:0};\n}'
 '.source.c\\+\\+, .source.objc\\+\\+':
   'Enumeration':
     'prefix': 'enum'


### PR DESCRIPTION
- Changed some snippets like the for loop, so you don't have to change `i` three times, it is edited at all three places at once now.
- Deleted a redundant line
- Added a snippet for a void function and one for other functions (with return values). I'm not sure about the latters prefix, though. It's now `func`, but if someone knows a better name, go ahead!
