### PR TITLE
Match 'override' and 'final' specifiers (C++11)

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -230,8 +230,8 @@
         'include': '#parens'
       }
       {
-        'match': '\\bconst\\b'
-        'name': 'storage.modifier.c'
+        'match': '\\b(const|override|final)\\b'
+        'name': 'storage.modifier.c++'
       }
       {
         'include': '#block'


### PR DESCRIPTION
Match the new C++11 'override' and 'final' special identifiers after a member function declaration.

Converted from a commit to textmate/c.tmbundle.
