### PR TITLE
Workaround for Allman-style indentation

### DIFF
--- a/scoped-properties/language-c.cson
+++ b/scoped-properties/language-c.cson
@@ -14,6 +14,7 @@
        ^ \\s* (\\s* /[*] .* [*]/ \\s*)* \\}
       |^ \\s* (public|private|protected): \\s* $
       |^ \\s* @(public|private|protected) \\s* $
+      |^ \\s* \\{
       '
 '.source.c, .source.c\\+\\+':
   'editor':


### PR DESCRIPTION
Resolves issue #47 by decreasing the indent when a line starts with an opening brace.
