### PR TITLE
Disabled indenting for one line for/while statements

### DIFF
--- a/scoped-properties/language-c.cson
+++ b/scoped-properties/language-c.cson
@@ -8,7 +8,7 @@
       |^ \\s* \\{ \\} $
       |^ \\s* if \\s* \\( (?!.*?(\\belse\\b|;\\s*$))
       |^ \\s* \\}? \\s* else \\s*$
-      |^ \\s* (for|while) \\s* \\(
+      |^ \\s* (for|while) \\s* \\( (?! .* ; \\s* $)
       '
     'decreaseIndentPattern': '(?x)
        ^ \\s* (\\s* /[*] .* [*]/ \\s*)* \\}


### PR DESCRIPTION
Resolves issue #38 by not indenting if the line ends with a semicolon.
