### PR TITLE
Removed hh from c++

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -8,7 +8,6 @@
   'cu'
   'cuh'
   'h'
-  'hh'
   'hpp'
   'hxx'
   'h++'


### PR DESCRIPTION
HH is a filetype used by [HackLang](https://hacklang.org). Fixes atom/atom#4416
