### PR TITLE
Consistent use of EOL and spaces in snippets

### DIFF
--- a/snippets/language-c.cson
+++ b/snippets/language-c.cson
@@ -13,10 +13,10 @@
     'body': '#if 0\n${1:#pragma mark -\n}#pragma mark $2\n#endif\n\n$0'
   'main()':
     'prefix': 'main'
-    'body': 'int main (int argc, char const *argv[])\n{\n\t${1:/* code */}\n\treturn 0;\n}'
+    'body': 'int main(int argc, char const *argv[]) {\n\t${1:/* code */}\n\treturn 0;\n}'
   'For Loop':
     'prefix': 'for'
-    'body': 'for(size_t ${1:i} = 0; $1 < ${2:count}; $1${3:++})\n{\n\t${4:/* code */}\n}'
+    'body': 'for (size_t ${1:i} = 0; $1 < ${2:count}; $1${3:++}) {\n\t${4:/* code */}\n}'
   'Header Include-Guard':
     'prefix': 'once'
     'body': '#ifndef ${1:SYMBOL}\n#define $1\n\n${2}\n\n#endif /* end of include guard: $1 */\n'
@@ -37,10 +37,10 @@
     'body': 'fprintf(${1:stderr}, "${2:%s}\\n", $3);$4'
   'If Condition':
     'prefix': 'if'
-    'body': 'if(${1:/* condition */})\n{\n\t${2:/* code */}\n}'
+    'body': 'if (${1:/* condition */}) {\n\t${2:/* code */}\n}'
   'Switch Statement': 
     'prefix': 'switch'
-    'body': 'switch(${1:/* expression */}) {\n\tcase ${2:/* value */}:\n}'
+    'body': 'switch (${1:/* expression */}) {\n\tcase ${2:/* value */}:\n}'
   'case':
     'prefix': 'cs'
     'body': 'case ${1:/* value */}:$0'
@@ -52,23 +52,23 @@
     'body': 'scanf(\"${1:%s}\\n\", $2);$3'
   'Struct':
     'prefix': 'st'
-    'body': 'struct ${1:name_t}\n{\n\t${2:/* data */}\n};'
+    'body': 'struct ${1:name_t} {\n\t${2:/* data */}\n};'
   'void':
     'prefix': 'void'
-    'body': 'void ${1:name} (${2:/* arguments */})\n{\n\t${3:/* code */}\n}'
+    'body': 'void ${1:name} (${2:/* arguments */}) {\n\t${3:/* code */}\n}'
   'any function':
     'prefix': 'func'
-    'body': '${1:int} ${2:name} (${3:/* arguments */})\n{\n\t${5:/* code */}\n\treturn ${4:0};\n}'
+    'body': '${1:int} ${2:name}(${3:/* arguments */}) {\n\t${5:/* code */}\n\treturn ${4:0};\n}'
 '.source.c\\+\\+, .source.objc\\+\\+':
   'Enumeration':
     'prefix': 'enum'
     'body': 'enum ${1:name} { $0 };'
   'Class':
     'prefix': 'cl'
-    'body': 'class ${1:name_t}\n{\npublic:\n\t${1:name_t} (${2:arguments});\n\tvirtual ~${1:name_t} ();\n\nprivate:\n\t${0:/* data */}\n};'
+    'body': 'class ${1:name_t} {\npublic:\n\t${1:name_t} (${2:arguments});\n\tvirtual ~${1:name_t} ();\n\nprivate:\n\t${0:/* data */}\n};'
   'Namespace':
     'prefix': 'ns'
-    'body': 'namespace ${1:name}\n{\n\t$2\n} /* $1 */'
+    'body': 'namespace ${1:name} {\n\t$2\n} /* $1 */'
   'std::map':
     'prefix': 'map'
     'body': 'std::map<${1:key}, ${2:value}> map$3;'


### PR DESCRIPTION
This PR addresses #52 for the sake of consistency in snippets, for example:
`for(` to `for (` # statement
`if(cond)\n{` to `if(cond) {` # statement, EOL to space
`main (` to `main(` # function
