### PR TITLE
Fix parenthesis scoping as meta.initialization (fix #30)

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -295,7 +295,7 @@
             'name': 'variable.other.c'
           '2':
             'name': 'punctuation.definition.parameters.c'
-        'match': '(?x)\n\t\t\t        (?x)\n\t\t\t(?:  \n\t\t\t     (?: (?= \\s )           (?<!else|new|return) (?<=\\w)\\s+      #  or word + space before name\n\t\t\t     )\n\t\t\t)\n\t\t\t(\n\t\t\t\t(?: [A-Za-z_][A-Za-z0-9_]*+ | :: )++    |              # actual name\n\t\t\t\t(?: (?<=operator) (?: [-*&<>=+!]+ | \\(\\) | \\[\\] ) )?  # if it is a C++ operator\n\t\t\t)\n\t\t\t \\s*(\\()'
+        'match': '(?x)\n\t\t\t        (?x)\n\t\t\t(?:  \n\t\t\t     (?: (?= \\s )           (?<!else|new|return) (?<=\\w)\\s+      #  or word + space before name\n\t\t\t     )\n\t\t\t)\n\t\t\t(\n\t\t\t\t(?: [A-Za-z_][A-Za-z0-9_]*+ | :: )++    |              # actual name\n\t\t\t\t(?: (?<=operator) (?: [-*&<>=+!]+ | \\(\\) | \\[\\] ) )  # if it is a C++ operator\n\t\t\t)\n\t\t\t \\s*(\\()'
         'name': 'meta.initialization.c'
       }
       {


### PR DESCRIPTION
After looking into issue #30 more carefully, it looks like this is a problem on the language-c syntax.

Context: improperly highlighted parenthesis, with the language-c grammar and [seti-syntax](https://github.com/jesseweed/seti-syntax) highlighting:
![if statement](https://cloud.githubusercontent.com/assets/1854439/3474962/cb024376-02ea-11e4-966d-c99b608fdeaa.png)

Inspecting the begin parenthesis after the if statement:

```c
void test()
{
    float Val = 1.0f;
    if (Val == 0.0f) {
        return;
    }
}
```
Revealed that it was being matched with the `punctuation.definition.parameters.c` scope under `meta.initialization.c`.
Examining the regex reveals that the following will actually match `   (` (i.e. word to whitespace boundary, whitespace, opening parenthesis):
```coffee
'match': '(?x)
    (?x)
    (?:
        (?:
            (?= \\s )
            (?<!else|new|return)
            (?<=\\w)\\s+      #  or word + space before name
        )
    )
    (
        (?: [A-Za-z_][A-Za-z0-9_]*+ | :: )++    |              # actual name
        (?: (?<=operator) (?: [-*&<>=+!]+ | \\(\\) | \\[\\] ) )?  # if it is a C++ operator
    )
    \\s*(\\()'
```
The culprit here is the `?` at the end of the "if it is a C++ operator" line. This enables the 1st capture group to match no characters. Thus the only thing left to match is the whitespace and second capture group at the end.

I haven't tested the side effects extensively, but it does seem to fix the if statement problem:
![screenshot from 2015-01-18 19 12 15](https://cloud.githubusercontent.com/assets/2917145/5794857/fa2ae764-9f45-11e4-8210-c3f0c170cc0b.png)
