### PR TITLE
add inl, tcc and tpp in recognized file types #66

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -12,7 +12,10 @@
   'hpp'
   'hxx'
   'h++'
+  'inl'
   'ipp'
+  'tcc'
+  'tpp'
 ]
 'firstLineMatch': '-\\*- C\\+\\+ -\\*-'
 'name': 'C++'


### PR DESCRIPTION
I used the file extensions list supported by Github (https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L392) suggested by @jplatte