### PR TITLE
Correctly escape backslashes generated by snippets

### DIFF
--- a/snippets/language-c.cson
+++ b/snippets/language-c.cson
@@ -34,7 +34,7 @@
     'body': 'while (${1:/* condition */}) {\n\t${2:/* code */}\n}'
   'fprintf':
     'prefix': 'fprintf'
-    'body': 'fprintf(${1:stderr}, "${2:%s}\\n", $3);$4'
+    'body': 'fprintf(${1:stderr}, "${2:%s}\\\\n", $3);$4'
   'If Condition':
     'prefix': 'if'
     'body': 'if (${1:/* condition */}) {\n\t${2:/* code */}\n}'
@@ -55,10 +55,10 @@
     'body': 'case ${1:/* value */}:$0'
   'printf':
     'prefix': 'printf'
-    'body': 'printf("${1:%s}\\n", $2);$3'
+    'body': 'printf("${1:%s}\\\\n", $2);$3'
   'scanf':
     'prefix': 'scanf'
-    'body': 'scanf(\"${1:%s}\\n\", $2);$3'
+    'body': 'scanf(\"${1:%s}\\\\n\", $2);$3'
   'Struct':
     'prefix': 'st'
     'body': 'struct ${1:name_t} {\n\t${2:/* data */}\n};'
@@ -70,10 +70,10 @@
     'body': '${1:int} ${2:name}(${3:/* arguments */}) {\n\t${5:/* code */}\n\treturn ${4:0};\n}'
   'write file':
     'prefix': 'wf'
-    'body': 'FILE *${1:fp};\n${1:fp} = fopen ("${2:filename.txt}","w");\nif (${1:fp}!=NULL)\n{\n\tfprintf(${1:fp},"${3:Some String\\n}");\n\tfclose (${1:fp});\n}'
+    'body': 'FILE *${1:fp};\n${1:fp} = fopen ("${2:filename.txt}","w");\nif (${1:fp}!=NULL)\n{\n\tfprintf(${1:fp},"${3:Some String\\\\n}");\n\tfclose (${1:fp});\n}'
   'read file':
     'prefix': 'rf'
-    'body': 'FILE *${1:fp};\n${1:fp} = fopen ("${2:filename.txt}","r");\nif (${1:fp}!=NULL)\n{\n\tfscanf(${1:fp},"${3:Some String\\n}", ${3:&var});\n\tfclose (${1:fp});\n}'
+    'body': 'FILE *${1:fp};\n${1:fp} = fopen ("${2:filename.txt}","r");\nif (${1:fp}!=NULL)\n{\n\tfscanf(${1:fp},"${3:Some String\\\\n}", ${3:&var});\n\tfclose (${1:fp});\n}'
 '.source.cpp, .source.objcpp':
   'Enumeration':
     'prefix': 'enum'
@@ -107,7 +107,7 @@
     'body': 'template <typename ${1:_InputIter}>'
   'output file':
     'prefix': 'outf'
-    'body': 'ofstream ${1:afile} ("${2:filename.txt}", ios::out);\nif(${1:afile}.is_open()) { \n\t${1:afile} << "${3:This is a line.}\\n";\n\t${1:afile}.close();\n}'
+    'body': 'ofstream ${1:afile} ("${2:filename.txt}", ios::out);\nif(${1:afile}.is_open()) { \n\t${1:afile} << "${3:This is a line.}\\\\n";\n\t${1:afile}.close();\n}'
   'input file':
     'prefix': 'inf'
     'body': 'ifstream ${1:afile} ("${2:filename.txt}",ios::in);\nif(${1:afile}.is_open()) { \n\tstring buffer;\n\twhile( getline(myfile,buffer) ) {\n\t\tcout << line << endl;\n\t}\n\t\t${1:afile}.close();\n\t}\nelse {\n\tcout << "Unable to open file" << endl;\n}'


### PR DESCRIPTION
This fixes https://github.com/atom/language-c/issues/71. See https://github.com/atom/snippets/issues/128#issuecomment-94142966 for the origin of this.

cc @kevinsawicki 