### PR TITLE
Tokenize 'this' for consistency

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -48,7 +48,11 @@
     'name': 'variable.other.readwrite.member.cpp'
   }
   {
-    'match': '\\b(this|nullptr)\\b'
+    'match': '\\bthis\\b'
+    'name': 'variable.language.this.cpp'
+  }
+  {
+    'match': '\\bnullptr\\b'
     'name': 'variable.language.cpp'
   }
   {

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -104,6 +104,11 @@ describe 'Language-C', ->
       expect(grammar).toBeTruthy()
       expect(grammar.scopeName).toBe 'source.cpp'
 
+    it 'tokenizes this with `.this` class', ->
+      {tokens} = grammar.tokenizeLine 'this.x'
+
+      expect(tokens[0]).toEqual value: 'this', scopes: ['source.cpp', 'variable.language.this.cpp']
+
     it 'tokenizes classes', ->
       lines = grammar.tokenizeLines '''
         class Thing {


### PR DESCRIPTION
See: atom/language-coffee-script#39

Fixes #37