### PR TITLE
Preprocessor directives improvements + specs

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -301,7 +301,7 @@
         'beginCaptures':
           '1':
             'name': 'storage.modifier.cpp'
-        'end': '(?<=\\})|(?=\\w)'
+        'end': '(?<=\\})|(?=\\w)|(?=\\s*#\\s*endif\\b)'
         'name': 'meta.extern-block.cpp'
         'patterns': [
           {
@@ -309,7 +309,7 @@
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.block.begin.c'
-            'end': '\\}'
+            'end': '\\}|(?=\\s*#\\s*endif\\b)'
             'endCaptures':
               '0':
                 'name': 'punctuation.section.block.end.c'

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -177,7 +177,7 @@
     ]
   }
   {
-    'begin': '^\\s*(?:((#)\\s*(?:define|defined|pragma|undef))|((#)\\s*(?:elif|else|if|ifdef|ifndef)))\\b'
+    'begin': '^\\s*(?:((#)\\s*(?:pragma|undef))|((#)\\s*(?:elif|else|if|ifdef|ifndef)))\\b'
     'beginCaptures':
       '1':
         'name': 'keyword.control.directive.c'

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -90,7 +90,19 @@
     ]
   }
   {
-    'begin': '(?x)\n        \t\t^\\s*(\\#)\\s*(define)\\s+             # define\n        \t\t((?<id>[a-zA-Z_][a-zA-Z0-9_]*))  # macro name\n        \t\t(?:                              # and optionally:\n        \t\t    (\\()                         # an open parenthesis\n        \t\t        (\n        \t\t            \\s* \\g<id> \\s*       # first argument\n        \t\t            ((,) \\s* \\g<id> \\s*)*  # additional arguments\n        \t\t            (?:\\.\\.\\.)?          # varargs ellipsis?\n        \t\t        )\n        \t\t    (\\))                         # a close parenthesis\n        \t\t)?\n        \t'
+    'begin': '''(?x)
+      ^\\s*(\\#)\\s*(define)\\s+        # define
+      ((?<id>[a-zA-Z_][a-zA-Z0-9_]*))   # macro name
+      (?:                               # and optionally:
+        (\\()
+          (
+            \\s* \\g<id> \\s*         # first argument
+            ((,) \\s* \\g<id> \\s*)*  # additional arguments
+            (?:\\.\\.\\.)?            # varargs ellipsis?
+          )
+        (\\))
+      )?
+    '''
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.keyword.c'

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -262,7 +262,7 @@
         'beginCaptures':
           '0':
             'name': 'punctuation.section.block.begin.c'
-        'end': '\\}'
+        'end': '\\}|(?=\\s*#\\s*endif\\b)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.block.end.c'

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -89,10 +89,6 @@
     'name': 'meta.preprocessor.macro.c'
     'patterns': [
       {
-        'match': '(?>\\\\\\s*\\n)'
-        'name': 'punctuation.separator.continuation.c'
-      }
-      {
         'include': '$base'
       }
     ]
@@ -108,8 +104,7 @@
     'name': 'meta.preprocessor.diagnostic.c'
     'patterns': [
       {
-        'match': '(?>\\\\\\s*\\n)'
-        'name': 'punctuation.separator.continuation.c'
+        'include': '#line_continuation_character'
       }
     ]
   }
@@ -124,8 +119,7 @@
     'name': 'meta.preprocessor.include.c'
     'patterns': [
       {
-        'match': '(?>\\\\\\s*\\n)'
-        'name': 'punctuation.separator.continuation.c'
+        'include': '#line_continuation_character'
       }
       {
         'begin': '"'
@@ -171,8 +165,7 @@
         'include': '#numbers'
       }
       {
-        'match': '(?>\\\\\\s*\\n)'
-        'name': 'punctuation.separator.continuation.c'
+        'include': '#line_continuation_character'
       }
     ]
   }
@@ -191,8 +184,7 @@
     'name': 'meta.preprocessor.c'
     'patterns': [
       {
-        'match': '(?>\\\\\\s*\\n)'
-        'name': 'punctuation.separator.continuation.c'
+        'include': '#line_continuation_character'
       }
     ]
   }
@@ -250,6 +242,9 @@
         'include': '#block'
       }
     ]
+  }
+  {
+    'include': '#line_continuation_character'
   }
 ]
 'repository':
@@ -375,8 +370,7 @@
             'name': 'comment.line.double-slash.c++'
             'patterns': [
               {
-                'match': '(?>\\\\\\s*\\n)'
-                'name': 'punctuation.separator.continuation.c++'
+                'include': '#line_continuation_character'
               }
             ]
           }
@@ -402,6 +396,15 @@
       '2':
         'name': 'support.function.C99.c'
     'match': '(\\s*)\\b(hypot(f|l)?|s(scanf|ystem|nprintf|ca(nf|lb(n(f|l)?|ln(f|l)?))|i(n(h(f|l)?|f|l)?|gn(al|bit))|tr(s(tr|pn)|nc(py|at|mp)|c(spn|hr|oll|py|at|mp)|to(imax|d|u(l(l)?|max)|k|f|l(d|l)?)|error|pbrk|ftime|len|rchr|xfrm)|printf|et(jmp|vbuf|locale|buf)|qrt(f|l)?|w(scanf|printf)|rand)|n(e(arbyint(f|l)?|xt(toward(f|l)?|after(f|l)?))|an(f|l)?)|c(s(in(h(f|l)?|f|l)?|qrt(f|l)?)|cos(h(f)?|f|l)?|imag(f|l)?|t(ime|an(h(f|l)?|f|l)?)|o(s(h(f|l)?|f|l)?|nj(f|l)?|pysign(f|l)?)|p(ow(f|l)?|roj(f|l)?)|e(il(f|l)?|xp(f|l)?)|l(o(ck|g(f|l)?)|earerr)|a(sin(h(f|l)?|f|l)?|cos(h(f|l)?|f|l)?|tan(h(f|l)?|f|l)?|lloc|rg(f|l)?|bs(f|l)?)|real(f|l)?|brt(f|l)?)|t(ime|o(upper|lower)|an(h(f|l)?|f|l)?|runc(f|l)?|gamma(f|l)?|mp(nam|file))|i(s(space|n(ormal|an)|cntrl|inf|digit|u(nordered|pper)|p(unct|rint)|finite|w(space|c(ntrl|type)|digit|upper|p(unct|rint)|lower|al(num|pha)|graph|xdigit|blank)|l(ower|ess(equal|greater)?)|al(num|pha)|gr(eater(equal)?|aph)|xdigit|blank)|logb(f|l)?|max(div|abs))|di(v|fftime)|_Exit|unget(c|wc)|p(ow(f|l)?|ut(s|c(har)?|wc(har)?)|error|rintf)|e(rf(c(f|l)?|f|l)?|x(it|p(2(f|l)?|f|l|m1(f|l)?)?))|v(s(scanf|nprintf|canf|printf|w(scanf|printf))|printf|f(scanf|printf|w(scanf|printf))|w(scanf|printf)|a_(start|copy|end|arg))|qsort|f(s(canf|e(tpos|ek))|close|tell|open|dim(f|l)?|p(classify|ut(s|c|w(s|c))|rintf)|e(holdexcept|set(e(nv|xceptflag)|round)|clearexcept|testexcept|of|updateenv|r(aiseexcept|ror)|get(e(nv|xceptflag)|round))|flush|w(scanf|ide|printf|rite)|loor(f|l)?|abs(f|l)?|get(s|c|pos|w(s|c))|re(open|e|ad|xp(f|l)?)|m(in(f|l)?|od(f|l)?|a(f|l|x(f|l)?)?))|l(d(iv|exp(f|l)?)|o(ngjmp|cal(time|econv)|g(1(p(f|l)?|0(f|l)?)|2(f|l)?|f|l|b(f|l)?)?)|abs|l(div|abs|r(int(f|l)?|ound(f|l)?))|r(int(f|l)?|ound(f|l)?)|gamma(f|l)?)|w(scanf|c(s(s(tr|pn)|nc(py|at|mp)|c(spn|hr|oll|py|at|mp)|to(imax|d|u(l(l)?|max)|k|f|l(d|l)?|mbs)|pbrk|ftime|len|r(chr|tombs)|xfrm)|to(b|mb)|rtomb)|printf|mem(set|c(hr|py|mp)|move))|a(s(sert|ctime|in(h(f|l)?|f|l)?)|cos(h(f|l)?|f|l)?|t(o(i|f|l(l)?)|exit|an(h(f|l)?|2(f|l)?|f|l)?)|b(s|ort))|g(et(s|c(har)?|env|wc(har)?)|mtime)|r(int(f|l)?|ound(f|l)?|e(name|alloc|wind|m(ove|quo(f|l)?|ainder(f|l)?))|a(nd|ise))|b(search|towc)|m(odf(f|l)?|em(set|c(hr|py|mp)|move)|ktime|alloc|b(s(init|towcs|rtowcs)|towc|len|r(towc|len))))\\b'
+  'line_continuation_character':
+    'patterns': [
+      {
+        'match': '(?>(\\\\)\\s*\\n)'
+        'captures':
+          '1':
+            'name': 'constant.character.escape.line-continuation.c'
+      }
+    ]
   'numbers':
     'patterns': [
       {
@@ -702,6 +705,9 @@
           {
             'include': '#string_placeholder'
           }
+          {
+            'include': '#line_continuation_character'
+          }
         ]
       }
       {
@@ -717,6 +723,9 @@
         'patterns': [
           {
             'include': '#string_escaped_char'
+          }
+          {
+            'include': '#line_continuation_character'
           }
         ]
       }

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -51,43 +51,10 @@
     'include': '#sizeof'
   }
   {
-    'match': '\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b'
-    'name': 'constant.numeric.c'
+    'include': '#numbers'
   }
   {
-    'begin': '"'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.c'
-    'end': '"'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.c'
-    'name': 'string.quoted.double.c'
-    'patterns': [
-      {
-        'include': '#string_escaped_char'
-      }
-      {
-        'include': '#string_placeholder'
-      }
-    ]
-  }
-  {
-    'begin': '\''
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.c'
-    'end': '\''
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.c'
-    'name': 'string.quoted.single.c'
-    'patterns': [
-      {
-        'include': '#string_escaped_char'
-      }
-    ]
+    'include': '#strings'
   }
   {
     'begin': '''(?x)
@@ -188,7 +155,29 @@
     'include': '#pragma-mark'
   }
   {
-    'begin': '^\\s*(?:((#)\\s*(?:define|defined|line|pragma|undef))|((#)\\s*(?:elif|else|if|ifdef|ifndef)))\\b'
+    'begin': '^\\s*((#)\\s*line)\\b'
+    'beginCaptures':
+      '1':
+        'name': 'keyword.control.directive.line.c'
+      '2':
+        'name': 'punctuation.definition.directive.c'
+    'end': '(?=(?://|/\\*))|(?<!\\\\)(?=\\n)'
+    'name': 'meta.preprocessor.c'
+    'patterns': [
+      {
+        'include': '#strings'
+      }
+      {
+        'include': '#numbers'
+      }
+      {
+        'match': '(?>\\\\\\s*\\n)'
+        'name': 'punctuation.separator.continuation.c'
+      }
+    ]
+  }
+  {
+    'begin': '^\\s*(?:((#)\\s*(?:define|defined|pragma|undef))|((#)\\s*(?:elif|else|if|ifdef|ifndef)))\\b'
     'beginCaptures':
       '1':
         'name': 'keyword.control.directive.c'
@@ -413,6 +402,13 @@
       '2':
         'name': 'support.function.C99.c'
     'match': '(\\s*)\\b(hypot(f|l)?|s(scanf|ystem|nprintf|ca(nf|lb(n(f|l)?|ln(f|l)?))|i(n(h(f|l)?|f|l)?|gn(al|bit))|tr(s(tr|pn)|nc(py|at|mp)|c(spn|hr|oll|py|at|mp)|to(imax|d|u(l(l)?|max)|k|f|l(d|l)?)|error|pbrk|ftime|len|rchr|xfrm)|printf|et(jmp|vbuf|locale|buf)|qrt(f|l)?|w(scanf|printf)|rand)|n(e(arbyint(f|l)?|xt(toward(f|l)?|after(f|l)?))|an(f|l)?)|c(s(in(h(f|l)?|f|l)?|qrt(f|l)?)|cos(h(f)?|f|l)?|imag(f|l)?|t(ime|an(h(f|l)?|f|l)?)|o(s(h(f|l)?|f|l)?|nj(f|l)?|pysign(f|l)?)|p(ow(f|l)?|roj(f|l)?)|e(il(f|l)?|xp(f|l)?)|l(o(ck|g(f|l)?)|earerr)|a(sin(h(f|l)?|f|l)?|cos(h(f|l)?|f|l)?|tan(h(f|l)?|f|l)?|lloc|rg(f|l)?|bs(f|l)?)|real(f|l)?|brt(f|l)?)|t(ime|o(upper|lower)|an(h(f|l)?|f|l)?|runc(f|l)?|gamma(f|l)?|mp(nam|file))|i(s(space|n(ormal|an)|cntrl|inf|digit|u(nordered|pper)|p(unct|rint)|finite|w(space|c(ntrl|type)|digit|upper|p(unct|rint)|lower|al(num|pha)|graph|xdigit|blank)|l(ower|ess(equal|greater)?)|al(num|pha)|gr(eater(equal)?|aph)|xdigit|blank)|logb(f|l)?|max(div|abs))|di(v|fftime)|_Exit|unget(c|wc)|p(ow(f|l)?|ut(s|c(har)?|wc(har)?)|error|rintf)|e(rf(c(f|l)?|f|l)?|x(it|p(2(f|l)?|f|l|m1(f|l)?)?))|v(s(scanf|nprintf|canf|printf|w(scanf|printf))|printf|f(scanf|printf|w(scanf|printf))|w(scanf|printf)|a_(start|copy|end|arg))|qsort|f(s(canf|e(tpos|ek))|close|tell|open|dim(f|l)?|p(classify|ut(s|c|w(s|c))|rintf)|e(holdexcept|set(e(nv|xceptflag)|round)|clearexcept|testexcept|of|updateenv|r(aiseexcept|ror)|get(e(nv|xceptflag)|round))|flush|w(scanf|ide|printf|rite)|loor(f|l)?|abs(f|l)?|get(s|c|pos|w(s|c))|re(open|e|ad|xp(f|l)?)|m(in(f|l)?|od(f|l)?|a(f|l|x(f|l)?)?))|l(d(iv|exp(f|l)?)|o(ngjmp|cal(time|econv)|g(1(p(f|l)?|0(f|l)?)|2(f|l)?|f|l|b(f|l)?)?)|abs|l(div|abs|r(int(f|l)?|ound(f|l)?))|r(int(f|l)?|ound(f|l)?)|gamma(f|l)?)|w(scanf|c(s(s(tr|pn)|nc(py|at|mp)|c(spn|hr|oll|py|at|mp)|to(imax|d|u(l(l)?|max)|k|f|l(d|l)?|mbs)|pbrk|ftime|len|r(chr|tombs)|xfrm)|to(b|mb)|rtomb)|printf|mem(set|c(hr|py|mp)|move))|a(s(sert|ctime|in(h(f|l)?|f|l)?)|cos(h(f|l)?|f|l)?|t(o(i|f|l(l)?)|exit|an(h(f|l)?|2(f|l)?|f|l)?)|b(s|ort))|g(et(s|c(har)?|env|wc(har)?)|mtime)|r(int(f|l)?|ound(f|l)?|e(name|alloc|wind|m(ove|quo(f|l)?|ainder(f|l)?))|a(nd|ise))|b(search|towc)|m(odf(f|l)?|em(set|c(hr|py|mp)|move)|ktime|alloc|b(s(init|towcs|rtowcs)|towc|len|r(towc|len))))\\b'
+  'numbers':
+    'patterns': [
+      {
+        'match': '\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b'
+        'name': 'constant.numeric.c'
+      }
+    ]
   'parens':
     'begin': '\\('
     'beginCaptures':
@@ -687,6 +683,44 @@
   'sizeof':
     'match': '\\b(sizeof)\\b'
     'name': 'keyword.operator.sizeof.c'
+  'strings':
+    'patterns': [
+      {
+        'begin': '"'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.c'
+        'end': '"'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.c'
+        'name': 'string.quoted.double.c'
+        'patterns': [
+          {
+            'include': '#string_escaped_char'
+          }
+          {
+            'include': '#string_placeholder'
+          }
+        ]
+      }
+      {
+        'begin': '\''
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.c'
+        'end': '\''
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.c'
+        'name': 'string.quoted.single.c'
+        'patterns': [
+          {
+            'include': '#string_escaped_char'
+          }
+        ]
+      }
+    ]
   'string_escaped_char':
     'patterns': [
       {

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -399,7 +399,7 @@
   'line_continuation_character':
     'patterns': [
       {
-        'match': '(?>(\\\\)\\s*\\n)'
+        'match': '(\\\\)\\s*\\n'
         'captures':
           '1':
             'name': 'constant.character.escape.line-continuation.c'

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -91,9 +91,9 @@
   }
   {
     'begin': '''(?x)
-      ^\\s*(\\#)\\s*(define)\\s+        # define
-      ((?<id>[a-zA-Z_][a-zA-Z0-9_]*))   # macro name
-      (?:                               # and optionally:
+      ^\\s* ((\\#)\\s*define) \\s+     # define
+      ((?<id>[a-zA-Z_][a-zA-Z0-9_]*))  # macro name
+      (?:
         (\\()
           (
             \\s* \\g<id> \\s*         # first argument
@@ -105,9 +105,9 @@
     '''
     'beginCaptures':
       '1':
-        'name': 'punctuation.definition.keyword.c'
+        'name': 'keyword.control.directive.define.c'
       '2':
-        'name': 'keyword.control.import.define.c'
+        'name': 'punctuation.definition.directive.c'
       '3':
         'name': 'entity.name.function.preprocessor.c'
       '5':
@@ -131,12 +131,12 @@
     ]
   }
   {
-    'begin': '^\\s*(#)\\s*(error|warning)\\b'
+    'begin': '^\\s*((#)\\s*(error|warning))\\b'
     'captures':
       '1':
-        'name': 'punctuation.definition.keyword.c'
+        'name': 'keyword.control.directive.diagnostic.$3.c'
       '2':
-        'name': 'keyword.control.import.error.c'
+        'name': 'punctuation.definition.directive.c'
     'end': '(?<!\\\\)(?=\\n)'
     'name': 'meta.preprocessor.diagnostic.c'
     'patterns': [
@@ -147,14 +147,14 @@
     ]
   }
   {
-    'begin': '^\\s*(#)\\s*(include|import)\\b\\s+'
+    'begin': '^\\s*((#)\\s*(include|import))\\b\\s+'
     'captures':
       '1':
-        'name': 'punctuation.definition.keyword.c'
+        'name': 'keyword.control.directive.$3.c'
       '2':
-        'name': 'keyword.control.import.include.c'
+        'name': 'punctuation.definition.directive.c'
     'end': '(?=(?://|/\\*))|(?<!\\\\)(?=\\n)'
-    'name': 'meta.preprocessor.c.include'
+    'name': 'meta.preprocessor.include.c'
     'patterns': [
       {
         'match': '(?>\\\\\\s*\\n)'
@@ -188,12 +188,16 @@
     'include': '#pragma-mark'
   }
   {
-    'begin': '^\\s*(#)\\s*(define|defined|elif|else|if|ifdef|ifndef|line|pragma|undef)\\b'
+    'begin': '^\\s*(?:((#)\\s*(?:define|defined|line|pragma|undef))|((#)\\s*(?:elif|else|if|ifdef|ifndef)))\\b'
     'captures':
       '1':
-        'name': 'punctuation.definition.keyword.c'
+        'name': 'keyword.control.directive.c'
       '2':
-        'name': 'keyword.control.import.c'
+        'name': 'punctuation.definition.directive.c'
+      '3':
+        'name': 'keyword.control.directive.conditional.c'
+      '4':
+        'name': 'punctuation.definition.directive.c'
     'end': '(?=(?://|/\\*))|(?<!\\\\)(?=\\n)'
     'name': 'meta.preprocessor.c'
     'patterns': [
@@ -426,34 +430,38 @@
     ]
   'pragma-mark':
     'captures':
-      '1':
+      '0':
         'name': 'meta.preprocessor.c'
+      '1':
+        'name': 'keyword.control.directive.pragma.pragma-mark.c'
       '2':
-        'name': 'punctuation.definition.keyword.c'
+        'name': 'punctuation.definition.directive.c'
       '3':
-        'name': 'keyword.control.import.pragma.c'
-      '4':
         'name': 'meta.toc-list.pragma-mark.c'
-    'match': '^\\s*((#)\\s*(pragma\\s+mark)\\s+(.*))'
+    'match': '^\\s*((#)\\s*pragma\\s+mark)\\s+(.*)'
     'name': 'meta.section'
   'preprocessor-rule-disabled':
-    'begin': '^\\s*(#(if)\\s+(0)\\b).*'
+    'begin': '^\\s*(((#)if)\\s+(0)\\b).*'
     'captures':
       '1':
         'name': 'meta.preprocessor.c'
       '2':
-        'name': 'keyword.control.import.if.c'
+        'name': 'keyword.control.directive.conditional.c'
       '3':
+        'name': 'punctuation.definition.directive.c'
+      '4':
         'name': 'constant.numeric.preprocessor.c'
-    'end': '^\\s*(#\\s*(endif)\\b)'
+    'end': '^\\s*(((#)\\s*endif)\\b)'
     'patterns': [
       {
-        'begin': '^\\s*(#\\s*(else)\\b)'
+        'begin': '^\\s*(((#)\\s*else)\\b)'
         'captures':
           '1':
             'name': 'meta.preprocessor.c'
           '2':
-            'name': 'keyword.control.import.else.c'
+            'name': 'keyword.control.directive.conditional.c'
+          '3':
+            'name': 'punctuation.definition.directive.c'
         'end': '(?=^\\s*#\\s*endif\\b)'
         'patterns': [
           {
@@ -476,23 +484,27 @@
       }
     ]
   'preprocessor-rule-disabled-block':
-    'begin': '^\\s*(#(if)\\s+(0)\\b).*'
+    'begin': '^\\s*(((#)if)\\s+(0)\\b).*'
     'captures':
       '1':
         'name': 'meta.preprocessor.c'
       '2':
-        'name': 'keyword.control.import.if.c'
+        'name': 'keyword.control.directive.conditional.c'
       '3':
+        'name': 'punctuation.definition.directive.c'
+      '4':
         'name': 'constant.numeric.preprocessor.c'
-    'end': '^\\s*(#\\s*(endif)\\b)'
+    'end': '^\\s*(((#)\\s*endif)\\b)'
     'patterns': [
       {
-        'begin': '^\\s*(#\\s*(else)\\b)'
+        'begin': '^\\s*(((#)\\s*else\\b))'
         'captures':
           '1':
             'name': 'meta.preprocessor.c'
           '2':
-            'name': 'keyword.control.import.else.c'
+            'name': 'keyword.control.directive.conditional.c'
+          '3':
+            'name': 'punctuation.definition.directive.c'
         'end': '(?=^\\s*#\\s*endif\\b)'
         'patterns': [
           {
@@ -515,23 +527,27 @@
       }
     ]
   'preprocessor-rule-enabled':
-    'begin': '^\\s*(#(if)\\s+(0*1)\\b)'
+    'begin': '^\\s*(((#)if)\\s+(0*1)\\b)'
     'captures':
       '1':
         'name': 'meta.preprocessor.c'
       '2':
-        'name': 'keyword.control.import.if.c'
+        'name': 'keyword.control.directive.conditional.c'
       '3':
+        'name': 'punctuation.definition.directive.c'
+      '4':
         'name': 'constant.numeric.preprocessor.c'
-    'end': '^\\s*(#\\s*(endif)\\b)'
+    'end': '^\\s*(((#)\\s*endif)\\b)'
     'patterns': [
       {
-        'begin': '^\\s*(#\\s*(else)\\b).*'
+        'begin': '^\\s*(((#)\\s*else)\\b).*'
         'captures':
           '1':
             'name': 'meta.preprocessor.c'
           '2':
-            'name': 'keyword.control.import.else.c'
+            'name': 'keyword.control.directive.conditional.c'
+          '3':
+            'name': 'punctuation.definition.directive.c'
         'contentName': 'comment.block.preprocessor.else-branch'
         'end': '(?=^\\s*#\\s*endif\\b)'
         'patterns': [
@@ -554,23 +570,27 @@
       }
     ]
   'preprocessor-rule-enabled-block':
-    'begin': '^\\s*(#(if)\\s+(0*1)\\b)'
+    'begin': '^\\s*(((#)if)\\s+(0*1)\\b)'
     'captures':
       '1':
         'name': 'meta.preprocessor.c'
       '2':
-        'name': 'keyword.control.import.if.c'
+        'name': 'keyword.control.directive.conditional.c'
       '3':
+        'name': 'punctuation.definition.directive.c'
+      '4':
         'name': 'constant.numeric.preprocessor.c'
-    'end': '^\\s*(#\\s*(endif)\\b)'
+    'end': '^\\s*(((#)\\s*endif)\\b)'
     'patterns': [
       {
-        'begin': '^\\s*(#\\s*(else)\\b).*'
+        'begin': '^\\s*(((#)\\s*else)\\b).*'
         'captures':
           '1':
             'name': 'meta.preprocessor.c'
           '2':
-            'name': 'keyword.control.import.else.c'
+            'name': 'keyword.control.directive.conditional.c'
+          '3':
+            'name': 'punctuation.definition.directive.c'
         'contentName': 'comment.block.preprocessor.else-branch.in-block'
         'end': '(?=^\\s*#\\s*endif\\b)'
         'patterns': [
@@ -593,28 +613,30 @@
       }
     ]
   'preprocessor-rule-other':
-    'begin': '^\\s*((#)\\s*(if(n?def)?)\\b.*?(?:(?=(?://|/\\*))|$))'
+    'begin': '^\\s*(((#)\\s*if(n?def)?)\\b.*?(?:(?=(?://|/\\*))|$))'
     'captures':
       '1':
         'name': 'meta.preprocessor.c'
       '2':
-        'name': 'punctuation.definition.keyword.c'
+        'name': 'keyword.control.directive.conditional.c'
       '3':
-        'name': 'keyword.control.import.c'
-    'end': '^\\s*((#)\\s*(endif)\\b)'
+        'name': 'punctuation.definition.directive.c'
+    'end': '^\\s*(((#)\\s*(endif))\\b)'
     'patterns': [
       {
         'include': '$base'
       }
     ]
   'preprocessor-rule-other-block':
-    'begin': '^\\s*(#\\s*(if(n?def)?)\\b.*?(?:(?=(?://|/\\*))|$))'
+    'begin': '^\\s*(((#)\\s*if(n?def)?)\\b.*?(?:(?=(?://|/\\*))|$))'
     'captures':
       '1':
         'name': 'meta.preprocessor.c'
       '2':
-        'name': 'keyword.control.import.c'
-    'end': '^\\s*(#\\s*(endif)\\b)'
+        'name': 'keyword.control.directive.conditional.c'
+      '3':
+        'name': 'punctuation.definition.directive.c'
+    'end': '^\\s*(((#)\\s*endif)\\b)'
     'patterns': [
       {
         'include': '#block_innards'

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -148,7 +148,7 @@
   }
   {
     'begin': '^\\s*((#)\\s*(include|import))\\b\\s+'
-    'captures':
+    'beginCaptures':
       '1':
         'name': 'keyword.control.directive.$3.c'
       '2':
@@ -189,7 +189,7 @@
   }
   {
     'begin': '^\\s*(?:((#)\\s*(?:define|defined|line|pragma|undef))|((#)\\s*(?:elif|else|if|ifdef|ifndef)))\\b'
-    'captures':
+    'beginCaptures':
       '1':
         'name': 'keyword.control.directive.c'
       '2':
@@ -442,7 +442,7 @@
     'name': 'meta.section'
   'preprocessor-rule-disabled':
     'begin': '^\\s*(((#)if)\\s+(0)\\b).*'
-    'captures':
+    'beginCaptures':
       '1':
         'name': 'meta.preprocessor.c'
       '2':
@@ -452,10 +452,17 @@
       '4':
         'name': 'constant.numeric.preprocessor.c'
     'end': '^\\s*(((#)\\s*endif)\\b)'
+    'endCaptures':
+      '1':
+        'name': 'meta.preprocessor.c'
+      '2':
+        'name': 'keyword.control.directive.conditional.c'
+      '3':
+        'name': 'punctuation.definition.directive.c'
     'patterns': [
       {
         'begin': '^\\s*(((#)\\s*else)\\b)'
-        'captures':
+        'beginCaptures':
           '1':
             'name': 'meta.preprocessor.c'
           '2':
@@ -485,7 +492,7 @@
     ]
   'preprocessor-rule-disabled-block':
     'begin': '^\\s*(((#)if)\\s+(0)\\b).*'
-    'captures':
+    'beginCaptures':
       '1':
         'name': 'meta.preprocessor.c'
       '2':
@@ -495,10 +502,17 @@
       '4':
         'name': 'constant.numeric.preprocessor.c'
     'end': '^\\s*(((#)\\s*endif)\\b)'
+    'endCaptures':
+      '1':
+        'name': 'meta.preprocessor.c'
+      '2':
+        'name': 'keyword.control.directive.conditional.c'
+      '3':
+        'name': 'punctuation.definition.directive.c'
     'patterns': [
       {
         'begin': '^\\s*(((#)\\s*else\\b))'
-        'captures':
+        'beginCaptures':
           '1':
             'name': 'meta.preprocessor.c'
           '2':
@@ -528,7 +542,7 @@
     ]
   'preprocessor-rule-enabled':
     'begin': '^\\s*(((#)if)\\s+(0*1)\\b)'
-    'captures':
+    'beginCaptures':
       '1':
         'name': 'meta.preprocessor.c'
       '2':
@@ -538,10 +552,17 @@
       '4':
         'name': 'constant.numeric.preprocessor.c'
     'end': '^\\s*(((#)\\s*endif)\\b)'
+    'endCaptures':
+      '1':
+        'name': 'meta.preprocessor.c'
+      '2':
+        'name': 'keyword.control.directive.conditional.c'
+      '3':
+        'name': 'punctuation.definition.directive.c'
     'patterns': [
       {
         'begin': '^\\s*(((#)\\s*else)\\b).*'
-        'captures':
+        'beginCaptures':
           '1':
             'name': 'meta.preprocessor.c'
           '2':
@@ -571,7 +592,7 @@
     ]
   'preprocessor-rule-enabled-block':
     'begin': '^\\s*(((#)if)\\s+(0*1)\\b)'
-    'captures':
+    'beginCaptures':
       '1':
         'name': 'meta.preprocessor.c'
       '2':
@@ -581,10 +602,17 @@
       '4':
         'name': 'constant.numeric.preprocessor.c'
     'end': '^\\s*(((#)\\s*endif)\\b)'
+    'endCaptures':
+      '1':
+        'name': 'meta.preprocessor.c'
+      '2':
+        'name': 'keyword.control.directive.conditional.c'
+      '3':
+        'name': 'punctuation.definition.directive.c'
     'patterns': [
       {
         'begin': '^\\s*(((#)\\s*else)\\b).*'
-        'captures':
+        'beginCaptures':
           '1':
             'name': 'meta.preprocessor.c'
           '2':
@@ -614,7 +642,7 @@
     ]
   'preprocessor-rule-other':
     'begin': '^\\s*(((#)\\s*if(n?def)?)\\b.*?(?:(?=(?://|/\\*))|$))'
-    'captures':
+    'beginCaptures':
       '1':
         'name': 'meta.preprocessor.c'
       '2':
@@ -622,6 +650,13 @@
       '3':
         'name': 'punctuation.definition.directive.c'
     'end': '^\\s*(((#)\\s*(endif))\\b)'
+    'endCaptures':
+      '1':
+        'name': 'meta.preprocessor.c'
+      '2':
+        'name': 'keyword.control.directive.conditional.c'
+      '3':
+        'name': 'punctuation.definition.directive.c'
     'patterns': [
       {
         'include': '$base'
@@ -629,7 +664,7 @@
     ]
   'preprocessor-rule-other-block':
     'begin': '^\\s*(((#)\\s*if(n?def)?)\\b.*?(?:(?=(?://|/\\*))|$))'
-    'captures':
+    'beginCaptures':
       '1':
         'name': 'meta.preprocessor.c'
       '2':
@@ -637,6 +672,13 @@
       '3':
         'name': 'punctuation.definition.directive.c'
     'end': '^\\s*(((#)\\s*endif)\\b)'
+    'endCaptures':
+      '1':
+        'name': 'meta.preprocessor.c'
+      '2':
+        'name': 'keyword.control.directive.conditional.c'
+      '3':
+        'name': 'punctuation.definition.directive.c'
     'patterns': [
       {
         'include': '#block_innards'

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -177,15 +177,15 @@
     ]
   }
   {
-    'begin': '^\\s*(?:((#)\\s*(pragma|undef))|((#)\\s*(?:elif|else|if|ifdef|ifndef)))\\b'
+    'begin': '^\\s*(?:((#)\\s*(?:elif|else|if|ifdef|ifndef))|((#)\\s*(pragma|undef)))\\b'
     'beginCaptures':
       '1':
-        'name': 'keyword.control.directive.$3.c'
+        'name': 'keyword.control.directive.conditional.c'
       '2':
         'name': 'punctuation.definition.directive.c'
+      '3':
+        'name': 'keyword.control.directive.$5.c'
       '4':
-        'name': 'keyword.control.directive.conditional.c'
-      '5':
         'name': 'punctuation.definition.directive.c'
     'end': '(?=(?://|/\\*))|(?<!\\\\)(?=\\n)'
     'name': 'meta.preprocessor.c'

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -114,7 +114,7 @@
     ]
   }
   {
-    'begin': '^\\s*((#)\\s*(include|import))\\b\\s+'
+    'begin': '^\\s*((#)\\s*(include|import))\\b\\s*'
     'beginCaptures':
       '1':
         'name': 'keyword.control.directive.$3.c'

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -430,15 +430,15 @@
     ]
   'pragma-mark':
     'captures':
-      '0':
-        'name': 'meta.preprocessor.c'
       '1':
-        'name': 'keyword.control.directive.pragma.pragma-mark.c'
+        'name': 'meta.preprocessor.c'
       '2':
-        'name': 'punctuation.definition.directive.c'
+        'name': 'keyword.control.directive.pragma.pragma-mark.c'
       '3':
+        'name': 'punctuation.definition.directive.c'
+      '4':
         'name': 'meta.toc-list.pragma-mark.c'
-    'match': '^\\s*((#)\\s*pragma\\s+mark)\\s+(.*)'
+    'match': '^\\s*(((#)\\s*pragma\\s+mark)\\s+(.*))'
     'name': 'meta.section'
   'preprocessor-rule-disabled':
     'begin': '^\\s*(((#)if)\\s+(0)\\b).*'

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -177,15 +177,15 @@
     ]
   }
   {
-    'begin': '^\\s*(?:((#)\\s*(?:pragma|undef))|((#)\\s*(?:elif|else|if|ifdef|ifndef)))\\b'
+    'begin': '^\\s*(?:((#)\\s*(pragma|undef))|((#)\\s*(?:elif|else|if|ifdef|ifndef)))\\b'
     'beginCaptures':
       '1':
-        'name': 'keyword.control.directive.c'
+        'name': 'keyword.control.directive.$3.c'
       '2':
         'name': 'punctuation.definition.directive.c'
-      '3':
-        'name': 'keyword.control.directive.conditional.c'
       '4':
+        'name': 'keyword.control.directive.conditional.c'
+      '5':
         'name': 'punctuation.definition.directive.c'
     'end': '(?=(?://|/\\*))|(?<!\\\\)(?=\\n)'
     'name': 'meta.preprocessor.c'

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -53,9 +53,12 @@ describe "Language-C", ->
     describe "preprocessor directives", ->
       it "tokenizes '#line'", ->
         {tokens} = grammar.tokenizeLine '#line 151 "copy.c"'
-        expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c', 'punctuation.definition.directive.c']
-        expect(tokens[1]).toEqual value: 'line', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c']
-        expect(tokens[2]).toEqual value: ' 151 "copy.c"', scopes: ['source.c', 'meta.preprocessor.c']
+        expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.line.c', 'punctuation.definition.directive.c']
+        expect(tokens[1]).toEqual value: 'line', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.line.c']
+        expect(tokens[3]).toEqual value: '151', scopes: ['source.c', 'meta.preprocessor.c', 'constant.numeric.c']
+        expect(tokens[5]).toEqual value: '"', scopes: ['source.c', 'meta.preprocessor.c', 'string.quoted.double.c', 'punctuation.definition.string.begin.c']
+        expect(tokens[6]).toEqual value: 'copy.c', scopes: ['source.c', 'meta.preprocessor.c', 'string.quoted.double.c']
+        expect(tokens[7]).toEqual value: '"', scopes: ['source.c', 'meta.preprocessor.c', 'string.quoted.double.c', 'punctuation.definition.string.end.c']
 
       it "tokenizes '#undef'", ->
         {tokens} = grammar.tokenizeLine '#undef FOO'

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -37,75 +37,6 @@ describe 'Language-C', ->
       expect(lines[1][3]).toEqual value: '0', scopes: ["source.c", "meta.function.c", "meta.block.c", "constant.numeric.c"]
       expect(lines[2][0]).toEqual value: '}', scopes: ["source.c", "meta.function.c", "meta.block.c", "punctuation.section.block.end.c"]
 
-    it 'tokenizes if-true-else preprocessor blocks', ->
-      lines = grammar.tokenizeLines '''
-        #if 1
-        int something() {
-          #if 1
-            return 1;
-          #else
-            return 0;
-          #endif
-        }
-        #else
-        int something() {
-          return 0;
-        }
-        #endif
-      '''
-      expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
-      expect(lines[0][1]).toEqual value: 'if', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
-      expect(lines[0][3]).toEqual value: '1', scopes: ['source.c', 'meta.preprocessor.c', 'constant.numeric.preprocessor.c']
-      expect(lines[1][0]).toEqual value: 'int', scopes: ['source.c', 'storage.type.c']
-      expect(lines[1][2]).toEqual value: 'something', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
-      expect(lines[2][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
-      expect(lines[2][2]).toEqual value: 'if', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
-      expect(lines[2][4]).toEqual value: '1', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'constant.numeric.preprocessor.c']
-      expect(lines[3][1]).toEqual value: 'return', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'keyword.control.c']
-      expect(lines[3][3]).toEqual value: '1', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'constant.numeric.c']
-      expect(lines[4][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
-      expect(lines[4][2]).toEqual value: 'else', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.else.c']
-      expect(lines[5][0]).toEqual value: '    return 0;', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'comment.block.preprocessor.else-branch.in-block']
-      expect(lines[6][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
-      expect(lines[6][2]).toEqual value: 'endif', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
-      expect(lines[8][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
-      expect(lines[8][1]).toEqual value: 'else', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.else.c']
-      expect(lines[9][0]).toEqual value: 'int something() {', scopes: ['source.c', 'comment.block.preprocessor.else-branch']
-      expect(lines[12][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
-      expect(lines[12][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
-
-    it 'tokenizes if-false-else preprocessor blocks', ->
-      lines = grammar.tokenizeLines '''
-        int something() {
-          #if 0
-            return 1;
-          #else
-            return 0;
-          #endif
-        }
-        #if 0
-          something();
-        #endif
-      '''
-      expect(lines[0][0]).toEqual value: 'int', scopes: ['source.c', 'storage.type.c']
-      expect(lines[0][2]).toEqual value: 'something', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
-      expect(lines[1][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
-      expect(lines[1][2]).toEqual value: 'if', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
-      expect(lines[1][4]).toEqual value: '0', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'constant.numeric.preprocessor.c']
-      expect(lines[2][0]).toEqual value: '    return 1;', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'comment.block.preprocessor.if-branch.in-block']
-      expect(lines[3][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
-      expect(lines[3][2]).toEqual value: 'else', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.else.c']
-      expect(lines[4][1]).toEqual value: 'return', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'keyword.control.c']
-      expect(lines[4][3]).toEqual value: '0', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'constant.numeric.c']
-      expect(lines[5][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
-      expect(lines[5][2]).toEqual value: 'endif', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
-      expect(lines[7][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
-      expect(lines[7][1]).toEqual value: 'if', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
-      expect(lines[7][3]).toEqual value: '0', scopes: ['source.c', 'meta.preprocessor.c', 'constant.numeric.preprocessor.c']
-      expect(lines[8][0]).toEqual value: '  something();', scopes: ['source.c', 'comment.block.preprocessor.if-branch']
-      expect(lines[9][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
-      expect(lines[9][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
-
     it 'tokenizes various _t types', ->
       {tokens} = grammar.tokenizeLine("size_t var;")
       expect(tokens[0]).toEqual value: 'size_t', scopes: ['source.c', 'support.type.sys-types.c']
@@ -118,6 +49,319 @@ describe 'Language-C', ->
 
       {tokens} = grammar.tokenizeLine("myType_t var;")
       expect(tokens[0]).toEqual value: 'myType_t', scopes: ['source.c', 'support.type.posix-reserved.c']
+
+    describe "preprocessor directives", ->
+      it 'tokenizes `#line`', ->
+        {tokens} = grammar.tokenizeLine '#line 151 "copy.c"'
+        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "punctuation.definition.keyword.c"]
+        expect(tokens[1]).toEqual value: 'line', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.import.c"]
+        expect(tokens[2]).toEqual value: ' 151 "copy.c"', scopes: ["source.c", "meta.preprocessor.c"]
+
+      it 'tokenizes `#undef`', ->
+        {tokens} = grammar.tokenizeLine '#undef FOO'
+        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "punctuation.definition.keyword.c"]
+        expect(tokens[1]).toEqual value: 'undef', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.import.c"]
+        expect(tokens[2]).toEqual value: ' FOO', scopes: ["source.c", "meta.preprocessor.c"]
+
+      it 'tokenizes `#pragma`', ->
+        {tokens} = grammar.tokenizeLine '#pragma once'
+        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "punctuation.definition.keyword.c"]
+        expect(tokens[1]).toEqual value: 'pragma', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.import.c"]
+        expect(tokens[2]).toEqual value: ' once', scopes: ["source.c", "meta.preprocessor.c"]
+
+        {tokens} = grammar.tokenizeLine '#pragma clang diagnostic push'
+        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "punctuation.definition.keyword.c"]
+        expect(tokens[1]).toEqual value: 'pragma', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.import.c"]
+        expect(tokens[2]).toEqual value: ' clang diagnostic push', scopes: ["source.c", "meta.preprocessor.c"]
+
+        {tokens} = grammar.tokenizeLine '#pragma mark – Initialization'
+        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.section", "meta.preprocessor.c",  "punctuation.definition.keyword.c"]
+        expect(tokens[1]).toEqual value: 'pragma mark', scopes: ["source.c", "meta.section",  "meta.preprocessor.c", "keyword.control.import.pragma.c"]
+        expect(tokens[3]).toEqual value: '– Initialization', scopes: ["source.c", "meta.section",  "meta.preprocessor.c", "meta.toc-list.pragma-mark.c"]
+
+      describe "define", ->
+        it 'tokenizes `#define [identifier name]`', ->
+          {tokens} = grammar.tokenizeLine '#define _FILE_NAME_H_'
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
+          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+          expect(tokens[3]).toEqual value: '_FILE_NAME_H_', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
+
+        it 'tokenizes `#define [identifier name] [value]`', ->
+          {tokens} = grammar.tokenizeLine '#define WIDTH 80'
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
+          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+          expect(tokens[3]).toEqual value: 'WIDTH', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
+          expect(tokens[5]).toEqual value: '80', scopes: ["source.c", "meta.preprocessor.macro.c", "constant.numeric.c"]
+
+          {tokens} = grammar.tokenizeLine '#define ABC XYZ(1)'
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
+          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+          expect(tokens[3]).toEqual value: 'ABC', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
+          expect(tokens[4]).toEqual value: ' ', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.function.c", "punctuation.whitespace.function.leading.c"]
+          expect(tokens[5]).toEqual value: 'XYZ', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.function.c", "entity.name.function.c"]
+          expect(tokens[6]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.function.c", "meta.parens.c", "punctuation.section.parens.begin.c"]
+          expect(tokens[7]).toEqual value: '1', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.function.c", "meta.parens.c", "constant.numeric.c"]
+          expect(tokens[8]).toEqual value: ')', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.function.c", "meta.parens.c", "punctuation.section.parens.end.c"]
+
+          {tokens} = grammar.tokenizeLine '#define PI_PLUS_ONE (3.14 + 1)'
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
+          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+          expect(tokens[3]).toEqual value: 'PI_PLUS_ONE', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
+          expect(tokens[4]).toEqual value: ' (', scopes: ["source.c", "meta.preprocessor.macro.c"]
+          expect(tokens[5]).toEqual value: '3.14', scopes: ["source.c", "meta.preprocessor.macro.c", "constant.numeric.c"]
+          expect(tokens[6]).toEqual value: ' + ', scopes: ["source.c", "meta.preprocessor.macro.c"]
+          expect(tokens[7]).toEqual value: '1', scopes: ["source.c", "meta.preprocessor.macro.c", "constant.numeric.c"]
+          expect(tokens[8]).toEqual value: ')', scopes: ["source.c", "meta.preprocessor.macro.c"]
+
+        describe "macros", ->
+          it 'tokenizes them', ->
+            {tokens} = grammar.tokenizeLine '#define INCREMENT(x) x++'
+            expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
+            expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+            expect(tokens[3]).toEqual value: 'INCREMENT', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
+            expect(tokens[4]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.begin.c"]
+            expect(tokens[5]).toEqual value: 'x', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
+            expect(tokens[6]).toEqual value: ')', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.end.c"]
+            expect(tokens[7]).toEqual value: ' x++', scopes: ["source.c", "meta.preprocessor.macro.c"]
+
+            {tokens} = grammar.tokenizeLine '#define MULT(x, y) (x) * (y)'
+            expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
+            expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+            expect(tokens[3]).toEqual value: 'MULT', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
+            expect(tokens[4]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.begin.c"]
+            expect(tokens[5]).toEqual value: 'x', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
+            expect(tokens[6]).toEqual value: ',', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c", "punctuation.separator.parameters.c"]
+            expect(tokens[7]).toEqual value: ' y', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
+            expect(tokens[8]).toEqual value: ')', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.end.c"]
+            expect(tokens[9]).toEqual value: ' (x) * (y)', scopes: ["source.c", "meta.preprocessor.macro.c"]
+
+            {tokens} = grammar.tokenizeLine '#define SWAP(a, b)  do { a ^= b; b ^= a; a ^= b; } while ( 0 )'
+            expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
+            expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+            expect(tokens[3]).toEqual value: 'SWAP', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
+            expect(tokens[4]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.begin.c"]
+            expect(tokens[5]).toEqual value: 'a', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
+            expect(tokens[6]).toEqual value: ',', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c", "punctuation.separator.parameters.c"]
+            expect(tokens[7]).toEqual value: ' b', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
+            expect(tokens[8]).toEqual value: ')', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.end.c"]
+            expect(tokens[10]).toEqual value: 'do', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.c"]
+            expect(tokens[12]).toEqual value: '{', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c", "punctuation.section.block.begin.c"]
+            expect(tokens[13]).toEqual value: ' a ^= b; b ^= a; a ^= b; ', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c"]
+            expect(tokens[14]).toEqual value: '}', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c", "punctuation.section.block.end.c"]
+            expect(tokens[16]).toEqual value: 'while', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.c"]
+            expect(tokens[17]).toEqual value: ' ( ', scopes: ["source.c", "meta.preprocessor.macro.c"]
+            expect(tokens[18]).toEqual value: '0', scopes: ["source.c", "meta.preprocessor.macro.c", "constant.numeric.c"]
+            expect(tokens[19]).toEqual value: ' )', scopes: ["source.c", "meta.preprocessor.macro.c"]
+
+          it 'tokenizes multiline macros', ->
+            lines = grammar.tokenizeLines '''
+              #define SWAP(a, b)  { \\
+                a ^= b; \\
+                b ^= a; \\
+                a ^= b; \\
+              }
+            '''
+            expect(lines[0][0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
+            expect(lines[0][1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+            expect(lines[0][3]).toEqual value: 'SWAP', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
+            expect(lines[0][4]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.begin.c"]
+            expect(lines[0][5]).toEqual value: 'a', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
+            expect(lines[0][6]).toEqual value: ',', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c", "punctuation.separator.parameters.c"]
+            expect(lines[0][7]).toEqual value: ' b', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
+            expect(lines[0][8]).toEqual value: ')', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.end.c"]
+            expect(lines[0][10]).toEqual value: '{', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c", "punctuation.section.block.begin.c"]
+            expect(lines[0][11]).toEqual value: ' \\', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c"]
+            expect(lines[1][0]).toEqual value: '  a ^= b; \\', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c"]
+            expect(lines[2][0]).toEqual value: '  b ^= a; \\', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c"]
+            expect(lines[3][0]).toEqual value: '  a ^= b; \\', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c"]
+            expect(lines[4][0]).toEqual value: '}', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c", "punctuation.section.block.end.c"]
+
+      describe 'includes', ->
+        it 'tokenizes `#include`', ->
+          {tokens} = grammar.tokenizeLine '#include <stdio.h>'
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c.include", "punctuation.definition.keyword.c"]
+          expect(tokens[1]).toEqual value: 'include', scopes: ["source.c", "meta.preprocessor.c.include", "keyword.control.import.include.c"]
+          expect(tokens[3]).toEqual value: '<', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.begin.c"]
+          expect(tokens[4]).toEqual value: 'stdio.h', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c"]
+          expect(tokens[5]).toEqual value: '>', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.end.c"]
+
+          {tokens} = grammar.tokenizeLine '#include "file">'
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c.include", "punctuation.definition.keyword.c"]
+          expect(tokens[1]).toEqual value: 'include', scopes: ["source.c", "meta.preprocessor.c.include", "keyword.control.import.include.c"]
+          expect(tokens[3]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.double.include.c", "punctuation.definition.string.begin.c"]
+          expect(tokens[4]).toEqual value: 'file', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.double.include.c"]
+          expect(tokens[5]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.double.include.c", "punctuation.definition.string.end.c"]
+
+        it 'tokenizes `#import`', ->
+          {tokens} = grammar.tokenizeLine '#import "file"'
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c.include", "punctuation.definition.keyword.c"]
+          expect(tokens[1]).toEqual value: 'import', scopes: ["source.c", "meta.preprocessor.c.include", "keyword.control.import.include.c"]
+          expect(tokens[3]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.double.include.c", "punctuation.definition.string.begin.c"]
+          expect(tokens[4]).toEqual value: 'file', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.double.include.c"]
+          expect(tokens[5]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.double.include.c", "punctuation.definition.string.end.c"]
+
+      describe 'diagnostics', ->
+        it 'tokenizes `#error`', ->
+          {tokens} = grammar.tokenizeLine '#error C++ compiler required.'
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "punctuation.definition.keyword.c"]
+          expect(tokens[1]).toEqual value: 'error', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "keyword.control.import.error.c"]
+          expect(tokens[2]).toEqual value: ' C++ compiler required.', scopes: ["source.c", "meta.preprocessor.diagnostic.c"]
+
+        it 'tokenizes `#warning`', ->
+          {tokens} = grammar.tokenizeLine '#warning This is a warning.'
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "punctuation.definition.keyword.c"]
+          expect(tokens[1]).toEqual value: 'warning', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "keyword.control.import.error.c"]
+          expect(tokens[2]).toEqual value: ' This is a warning.', scopes: ["source.c", "meta.preprocessor.diagnostic.c"]
+
+      describe 'conditionals', ->
+        it 'tokenizes if-elif-else preprocessor blocks', ->
+          lines = grammar.tokenizeLines '''
+            #if defined(CREDIT)
+                credit();
+            #elif defined(DEBIT)
+                debit();
+            #else
+                printerror();
+            #endif
+          '''
+          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
+          expect(lines[0][1]).toEqual value: 'if', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[0][2]).toEqual value: ' defined(CREDIT)', scopes: ['source.c', 'meta.preprocessor.c']
+          expect(lines[1][1]).toEqual value: 'credit', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
+          expect(lines[1][2]).toEqual value: '(', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.begin.c']
+          expect(lines[1][3]).toEqual value: ')', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.end.c']
+          expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
+          expect(lines[2][1]).toEqual value: 'elif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[2][2]).toEqual value: ' defined(DEBIT)', scopes: ['source.c', 'meta.preprocessor.c']
+          expect(lines[3][1]).toEqual value: 'debit', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
+          expect(lines[3][2]).toEqual value: '(', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.begin.c']
+          expect(lines[3][3]).toEqual value: ')', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.end.c']
+          expect(lines[4][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
+          expect(lines[4][1]).toEqual value: 'else', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[5][1]).toEqual value: 'printerror', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
+          expect(lines[5][2]).toEqual value: '(', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.begin.c']
+          expect(lines[5][3]).toEqual value: ')', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.end.c']
+          expect(lines[6][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
+          expect(lines[6][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+
+        it 'tokenizes if-true-else blocks', ->
+          lines = grammar.tokenizeLines '''
+            #if 1
+            int something() {
+              #if 1
+                return 1;
+              #else
+                return 0;
+              #endif
+            }
+            #else
+            int something() {
+              return 0;
+            }
+            #endif
+          '''
+          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
+          expect(lines[0][1]).toEqual value: 'if', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+          expect(lines[0][3]).toEqual value: '1', scopes: ['source.c', 'meta.preprocessor.c', 'constant.numeric.preprocessor.c']
+          expect(lines[1][0]).toEqual value: 'int', scopes: ['source.c', 'storage.type.c']
+          expect(lines[1][2]).toEqual value: 'something', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
+          expect(lines[2][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
+          expect(lines[2][2]).toEqual value: 'if', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+          expect(lines[2][4]).toEqual value: '1', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'constant.numeric.preprocessor.c']
+          expect(lines[3][1]).toEqual value: 'return', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'keyword.control.c']
+          expect(lines[3][3]).toEqual value: '1', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'constant.numeric.c']
+          expect(lines[4][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
+          expect(lines[4][2]).toEqual value: 'else', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.else.c']
+          expect(lines[5][0]).toEqual value: '    return 0;', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'comment.block.preprocessor.else-branch.in-block']
+          expect(lines[6][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
+          expect(lines[6][2]).toEqual value: 'endif', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+          expect(lines[8][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
+          expect(lines[8][1]).toEqual value: 'else', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.else.c']
+          expect(lines[9][0]).toEqual value: 'int something() {', scopes: ['source.c', 'comment.block.preprocessor.else-branch']
+          expect(lines[12][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
+          expect(lines[12][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+
+        it 'tokenizes if-false-else blocks', ->
+          lines = grammar.tokenizeLines '''
+            int something() {
+              #if 0
+                return 1;
+              #else
+                return 0;
+              #endif
+            }
+          '''
+          expect(lines[0][0]).toEqual value: 'int', scopes: ['source.c', 'storage.type.c']
+          expect(lines[0][2]).toEqual value: 'something', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
+          expect(lines[1][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
+          expect(lines[1][2]).toEqual value: 'if', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+          expect(lines[1][4]).toEqual value: '0', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'constant.numeric.preprocessor.c']
+          expect(lines[2][0]).toEqual value: '    return 1;', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'comment.block.preprocessor.if-branch.in-block']
+          expect(lines[3][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
+          expect(lines[3][2]).toEqual value: 'else', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.else.c']
+          expect(lines[4][1]).toEqual value: 'return', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'keyword.control.c']
+          expect(lines[4][3]).toEqual value: '0', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'constant.numeric.c']
+          expect(lines[5][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
+          expect(lines[5][2]).toEqual value: 'endif', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+
+          lines = grammar.tokenizeLines '''
+            #if 0
+              something();
+            #endif
+          '''
+          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
+          expect(lines[0][1]).toEqual value: 'if', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+          expect(lines[0][3]).toEqual value: '0', scopes: ['source.c', 'meta.preprocessor.c', 'constant.numeric.preprocessor.c']
+          expect(lines[1][0]).toEqual value: '  something();', scopes: ['source.c', 'comment.block.preprocessor.if-branch']
+          expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
+          expect(lines[2][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+
+        it 'tokenizes ifdef-elif blocks', ->
+          lines = grammar.tokenizeLines '''
+            #ifdef __unix__ /* is defined by compilers targeting Unix systems */
+              # include <unistd.h>
+            #elif defined _WIN32 /* is defined by compilers targeting Windows systems */
+              # include <windows.h>
+            #endif
+          '''
+          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
+          expect(lines[0][1]).toEqual value: 'ifdef', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[0][2]).toEqual value: ' __unix__ ', scopes: ['source.c', 'meta.preprocessor.c']
+          expect(lines[0][3]).toEqual value: '/*', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.begin.c']
+          expect(lines[0][4]).toEqual value: ' is defined by compilers targeting Unix systems ', scopes: ['source.c', 'comment.block.c']
+          expect(lines[0][5]).toEqual value: '*/', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.end.c']
+          expect(lines[1][1]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c.include", "punctuation.definition.keyword.c"]
+          expect(lines[1][3]).toEqual value: 'include', scopes: ["source.c", "meta.preprocessor.c.include", "keyword.control.import.include.c"]
+          expect(lines[1][5]).toEqual value: '<', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.begin.c"]
+          expect(lines[1][6]).toEqual value: 'unistd.h', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c"]
+          expect(lines[1][7]).toEqual value: '>', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.end.c"]
+          expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
+          expect(lines[2][1]).toEqual value: 'elif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[2][2]).toEqual value: ' defined _WIN32 ', scopes: ['source.c', 'meta.preprocessor.c']
+          expect(lines[2][3]).toEqual value: '/*', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.begin.c']
+          expect(lines[2][4]).toEqual value: ' is defined by compilers targeting Windows systems ', scopes: ['source.c', 'comment.block.c']
+          expect(lines[2][5]).toEqual value: '*/', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.end.c']
+          expect(lines[3][3]).toEqual value: 'include', scopes: ["source.c", "meta.preprocessor.c.include", "keyword.control.import.include.c"]
+          expect(lines[3][5]).toEqual value: '<', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.begin.c"]
+          expect(lines[3][6]).toEqual value: 'windows.h', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c"]
+          expect(lines[3][7]).toEqual value: '>', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.end.c"]
+          expect(lines[4][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
+          expect(lines[4][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+
+        it 'tokenizes ifndef blocks', ->
+          lines = grammar.tokenizeLines '''
+            #ifndef _INCL_GUARD
+              #define _INCL_GUARD
+            #endif
+          '''
+          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
+          expect(lines[0][1]).toEqual value: 'ifndef', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[0][2]).toEqual value: ' _INCL_GUARD', scopes: ['source.c', 'meta.preprocessor.c']
+          expect(lines[1][1]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
+          expect(lines[1][2]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+          expect(lines[1][4]).toEqual value: '_INCL_GUARD', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
+          expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
+          expect(lines[2][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
 
     describe "indentation", ->
       editor = null

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -214,6 +214,16 @@ describe "Language-C", ->
           expect(tokens[4]).toEqual value: 'stdio.h', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c']
           expect(tokens[5]).toEqual value: '>', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c', 'punctuation.definition.string.end.c']
 
+          {tokens} = grammar.tokenizeLine '#include<stdio.h>'
+          expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c', 'punctuation.definition.directive.c']
+          expect(tokens[1]).toEqual value: 'include', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c']
+          expect(tokens[2]).toEqual value: '<', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c', 'punctuation.definition.string.begin.c']
+          expect(tokens[3]).toEqual value: 'stdio.h', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c']
+          expect(tokens[4]).toEqual value: '>', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c', 'punctuation.definition.string.end.c']
+
+          {tokens} = grammar.tokenizeLine '#include_<stdio.h>'
+          expect(tokens[0]).toEqual value: '#include_<stdio.h>', scopes: ['source.c']
+
           {tokens} = grammar.tokenizeLine '#include "file"'
           expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c', 'punctuation.definition.directive.c']
           expect(tokens[1]).toEqual value: 'include', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c']

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -50,6 +50,18 @@ describe "Language-C", ->
       {tokens} = grammar.tokenizeLine('myType_t var;')
       expect(tokens[0]).toEqual value: 'myType_t', scopes: ['source.c', 'support.type.posix-reserved.c']
 
+    describe "strings", ->
+      it "tokenizes them", ->
+        delimsByScope =
+          'string.quoted.double.c': '"'
+          'string.quoted.single.c': '\''
+
+        for scope, delim of delimsByScope
+          {tokens} = grammar.tokenizeLine delim + 'a' + delim
+          expect(tokens[0]).toEqual value: delim, scopes: ['source.c', scope, 'punctuation.definition.string.begin.c']
+          expect(tokens[1]).toEqual value: 'a', scopes: ['source.c', scope]
+          expect(tokens[2]).toEqual value: delim, scopes: ['source.c', scope, 'punctuation.definition.string.end.c']
+
     describe "preprocessor directives", ->
       it "tokenizes '#line'", ->
         {tokens} = grammar.tokenizeLine '#line 151 "copy.c"'

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -27,7 +27,6 @@ describe 'Language-C', ->
           return 0;
         }
       '''
-
       expect(lines[0][0]).toEqual value: 'int', scopes: ["source.c", "storage.type.c"]
       expect(lines[0][2]).toEqual value: 'something', scopes: ["source.c", "meta.function.c", "entity.name.function.c"]
       expect(lines[0][3]).toEqual value: '(', scopes: ["source.c", "meta.function.c", "meta.parens.c", "punctuation.section.parens.begin.c"]
@@ -54,7 +53,6 @@ describe 'Language-C', ->
         }
         #endif
       '''
-
       expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
       expect(lines[0][1]).toEqual value: 'if', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
       expect(lines[0][3]).toEqual value: '1', scopes: ['source.c', 'meta.preprocessor.c', 'constant.numeric.preprocessor.c']
@@ -89,7 +87,6 @@ describe 'Language-C', ->
           something();
         #endif
       '''
-
       expect(lines[0][0]).toEqual value: 'int', scopes: ['source.c', 'storage.type.c']
       expect(lines[0][2]).toEqual value: 'something', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
       expect(lines[1][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
@@ -203,7 +200,6 @@ describe 'Language-C', ->
 
     it 'tokenizes this with `.this` class', ->
       {tokens} = grammar.tokenizeLine 'this.x'
-
       expect(tokens[0]).toEqual value: 'this', scopes: ['source.cpp', 'variable.language.this.cpp']
 
     it 'tokenizes classes', ->
@@ -212,6 +208,5 @@ describe 'Language-C', ->
           int x;
         }
       '''
-
       expect(lines[0][0]).toEqual value: 'class', scopes: ["source.cpp", "meta.class-struct-block.cpp", "storage.type.cpp"]
       expect(lines[0][2]).toEqual value: 'Thing', scopes: ["source.cpp", "meta.class-struct-block.cpp", "entity.name.type.cpp"]

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -53,49 +53,49 @@ describe 'Language-C', ->
     describe "preprocessor directives", ->
       it 'tokenizes `#line`', ->
         {tokens} = grammar.tokenizeLine '#line 151 "copy.c"'
-        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "punctuation.definition.keyword.c"]
-        expect(tokens[1]).toEqual value: 'line', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.import.c"]
+        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c", "punctuation.definition.directive.c"]
+        expect(tokens[1]).toEqual value: 'line', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c"]
         expect(tokens[2]).toEqual value: ' 151 "copy.c"', scopes: ["source.c", "meta.preprocessor.c"]
 
       it 'tokenizes `#undef`', ->
         {tokens} = grammar.tokenizeLine '#undef FOO'
-        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "punctuation.definition.keyword.c"]
-        expect(tokens[1]).toEqual value: 'undef', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.import.c"]
+        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c", "punctuation.definition.directive.c"]
+        expect(tokens[1]).toEqual value: 'undef', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c"]
         expect(tokens[2]).toEqual value: ' FOO', scopes: ["source.c", "meta.preprocessor.c"]
 
       it 'tokenizes `#pragma`', ->
         {tokens} = grammar.tokenizeLine '#pragma once'
-        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "punctuation.definition.keyword.c"]
-        expect(tokens[1]).toEqual value: 'pragma', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.import.c"]
+        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c", "punctuation.definition.directive.c"]
+        expect(tokens[1]).toEqual value: 'pragma', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c"]
         expect(tokens[2]).toEqual value: ' once', scopes: ["source.c", "meta.preprocessor.c"]
 
         {tokens} = grammar.tokenizeLine '#pragma clang diagnostic push'
-        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "punctuation.definition.keyword.c"]
-        expect(tokens[1]).toEqual value: 'pragma', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.import.c"]
+        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c", "punctuation.definition.directive.c"]
+        expect(tokens[1]).toEqual value: 'pragma', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c"]
         expect(tokens[2]).toEqual value: ' clang diagnostic push', scopes: ["source.c", "meta.preprocessor.c"]
 
         {tokens} = grammar.tokenizeLine '#pragma mark – Initialization'
-        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.section", "meta.preprocessor.c",  "punctuation.definition.keyword.c"]
-        expect(tokens[1]).toEqual value: 'pragma mark', scopes: ["source.c", "meta.section",  "meta.preprocessor.c", "keyword.control.import.pragma.c"]
+        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.section", "meta.preprocessor.c", "keyword.control.directive.pragma.pragma-mark.c",  "punctuation.definition.directive.c"]
+        expect(tokens[1]).toEqual value: 'pragma mark', scopes: ["source.c", "meta.section",  "meta.preprocessor.c", "keyword.control.directive.pragma.pragma-mark.c"]
         expect(tokens[3]).toEqual value: '– Initialization', scopes: ["source.c", "meta.section",  "meta.preprocessor.c", "meta.toc-list.pragma-mark.c"]
 
       describe "define", ->
         it 'tokenizes `#define [identifier name]`', ->
           {tokens} = grammar.tokenizeLine '#define _FILE_NAME_H_'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
-          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
+          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
           expect(tokens[3]).toEqual value: '_FILE_NAME_H_', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
 
         it 'tokenizes `#define [identifier name] [value]`', ->
           {tokens} = grammar.tokenizeLine '#define WIDTH 80'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
-          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
+          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
           expect(tokens[3]).toEqual value: 'WIDTH', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
           expect(tokens[5]).toEqual value: '80', scopes: ["source.c", "meta.preprocessor.macro.c", "constant.numeric.c"]
 
           {tokens} = grammar.tokenizeLine '#define ABC XYZ(1)'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
-          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
+          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
           expect(tokens[3]).toEqual value: 'ABC', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
           expect(tokens[4]).toEqual value: ' ', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.function.c", "punctuation.whitespace.function.leading.c"]
           expect(tokens[5]).toEqual value: 'XYZ', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.function.c", "entity.name.function.c"]
@@ -104,8 +104,8 @@ describe 'Language-C', ->
           expect(tokens[8]).toEqual value: ')', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.function.c", "meta.parens.c", "punctuation.section.parens.end.c"]
 
           {tokens} = grammar.tokenizeLine '#define PI_PLUS_ONE (3.14 + 1)'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
-          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
+          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
           expect(tokens[3]).toEqual value: 'PI_PLUS_ONE', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
           expect(tokens[4]).toEqual value: ' (', scopes: ["source.c", "meta.preprocessor.macro.c"]
           expect(tokens[5]).toEqual value: '3.14', scopes: ["source.c", "meta.preprocessor.macro.c", "constant.numeric.c"]
@@ -116,8 +116,8 @@ describe 'Language-C', ->
         describe "macros", ->
           it 'tokenizes them', ->
             {tokens} = grammar.tokenizeLine '#define INCREMENT(x) x++'
-            expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
-            expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+            expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
+            expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
             expect(tokens[3]).toEqual value: 'INCREMENT', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
             expect(tokens[4]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.begin.c"]
             expect(tokens[5]).toEqual value: 'x', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
@@ -125,8 +125,8 @@ describe 'Language-C', ->
             expect(tokens[7]).toEqual value: ' x++', scopes: ["source.c", "meta.preprocessor.macro.c"]
 
             {tokens} = grammar.tokenizeLine '#define MULT(x, y) (x) * (y)'
-            expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
-            expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+            expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
+            expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
             expect(tokens[3]).toEqual value: 'MULT', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
             expect(tokens[4]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.begin.c"]
             expect(tokens[5]).toEqual value: 'x', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
@@ -136,8 +136,8 @@ describe 'Language-C', ->
             expect(tokens[9]).toEqual value: ' (x) * (y)', scopes: ["source.c", "meta.preprocessor.macro.c"]
 
             {tokens} = grammar.tokenizeLine '#define SWAP(a, b)  do { a ^= b; b ^= a; a ^= b; } while ( 0 )'
-            expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
-            expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+            expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
+            expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
             expect(tokens[3]).toEqual value: 'SWAP', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
             expect(tokens[4]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.begin.c"]
             expect(tokens[5]).toEqual value: 'a', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
@@ -161,8 +161,8 @@ describe 'Language-C', ->
                 a ^= b; \\
               }
             '''
-            expect(lines[0][0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
-            expect(lines[0][1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+            expect(lines[0][0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
+            expect(lines[0][1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
             expect(lines[0][3]).toEqual value: 'SWAP', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
             expect(lines[0][4]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.begin.c"]
             expect(lines[0][5]).toEqual value: 'a', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
@@ -179,38 +179,38 @@ describe 'Language-C', ->
       describe 'includes', ->
         it 'tokenizes `#include`', ->
           {tokens} = grammar.tokenizeLine '#include <stdio.h>'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c.include", "punctuation.definition.keyword.c"]
-          expect(tokens[1]).toEqual value: 'include', scopes: ["source.c", "meta.preprocessor.c.include", "keyword.control.import.include.c"]
-          expect(tokens[3]).toEqual value: '<', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.begin.c"]
-          expect(tokens[4]).toEqual value: 'stdio.h', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c"]
-          expect(tokens[5]).toEqual value: '>', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.end.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c", "punctuation.definition.directive.c"]
+          expect(tokens[1]).toEqual value: 'include', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c"]
+          expect(tokens[3]).toEqual value: '<', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.begin.c"]
+          expect(tokens[4]).toEqual value: 'stdio.h', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c"]
+          expect(tokens[5]).toEqual value: '>', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.end.c"]
 
           {tokens} = grammar.tokenizeLine '#include "file">'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c.include", "punctuation.definition.keyword.c"]
-          expect(tokens[1]).toEqual value: 'include', scopes: ["source.c", "meta.preprocessor.c.include", "keyword.control.import.include.c"]
-          expect(tokens[3]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.double.include.c", "punctuation.definition.string.begin.c"]
-          expect(tokens[4]).toEqual value: 'file', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.double.include.c"]
-          expect(tokens[5]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.double.include.c", "punctuation.definition.string.end.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c", "punctuation.definition.directive.c"]
+          expect(tokens[1]).toEqual value: 'include', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c"]
+          expect(tokens[3]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.double.include.c", "punctuation.definition.string.begin.c"]
+          expect(tokens[4]).toEqual value: 'file', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.double.include.c"]
+          expect(tokens[5]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.double.include.c", "punctuation.definition.string.end.c"]
 
         it 'tokenizes `#import`', ->
           {tokens} = grammar.tokenizeLine '#import "file"'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c.include", "punctuation.definition.keyword.c"]
-          expect(tokens[1]).toEqual value: 'import', scopes: ["source.c", "meta.preprocessor.c.include", "keyword.control.import.include.c"]
-          expect(tokens[3]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.double.include.c", "punctuation.definition.string.begin.c"]
-          expect(tokens[4]).toEqual value: 'file', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.double.include.c"]
-          expect(tokens[5]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.double.include.c", "punctuation.definition.string.end.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.import.c", "punctuation.definition.directive.c"]
+          expect(tokens[1]).toEqual value: 'import', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.import.c"]
+          expect(tokens[3]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.double.include.c", "punctuation.definition.string.begin.c"]
+          expect(tokens[4]).toEqual value: 'file', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.double.include.c"]
+          expect(tokens[5]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.double.include.c", "punctuation.definition.string.end.c"]
 
       describe 'diagnostics', ->
         it 'tokenizes `#error`', ->
           {tokens} = grammar.tokenizeLine '#error C++ compiler required.'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "punctuation.definition.keyword.c"]
-          expect(tokens[1]).toEqual value: 'error', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "keyword.control.import.error.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "keyword.control.directive.diagnostic.error.c", "punctuation.definition.directive.c"]
+          expect(tokens[1]).toEqual value: 'error', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "keyword.control.directive.diagnostic.error.c"]
           expect(tokens[2]).toEqual value: ' C++ compiler required.', scopes: ["source.c", "meta.preprocessor.diagnostic.c"]
 
         it 'tokenizes `#warning`', ->
           {tokens} = grammar.tokenizeLine '#warning This is a warning.'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "punctuation.definition.keyword.c"]
-          expect(tokens[1]).toEqual value: 'warning', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "keyword.control.import.error.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "keyword.control.directive.diagnostic.warning.c", "punctuation.definition.directive.c"]
+          expect(tokens[1]).toEqual value: 'warning', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "keyword.control.directive.diagnostic.warning.c"]
           expect(tokens[2]).toEqual value: ' This is a warning.', scopes: ["source.c", "meta.preprocessor.diagnostic.c"]
 
       describe 'conditionals', ->
@@ -224,25 +224,25 @@ describe 'Language-C', ->
                 printerror();
             #endif
           '''
-          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
-          expect(lines[0][1]).toEqual value: 'if', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[0][1]).toEqual value: 'if', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[0][2]).toEqual value: ' defined(CREDIT)', scopes: ['source.c', 'meta.preprocessor.c']
           expect(lines[1][1]).toEqual value: 'credit', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
           expect(lines[1][2]).toEqual value: '(', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.begin.c']
           expect(lines[1][3]).toEqual value: ')', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.end.c']
-          expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
-          expect(lines[2][1]).toEqual value: 'elif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[2][1]).toEqual value: 'elif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[2][2]).toEqual value: ' defined(DEBIT)', scopes: ['source.c', 'meta.preprocessor.c']
           expect(lines[3][1]).toEqual value: 'debit', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
           expect(lines[3][2]).toEqual value: '(', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.begin.c']
           expect(lines[3][3]).toEqual value: ')', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.end.c']
-          expect(lines[4][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
-          expect(lines[4][1]).toEqual value: 'else', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[4][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[4][1]).toEqual value: 'else', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[5][1]).toEqual value: 'printerror', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
           expect(lines[5][2]).toEqual value: '(', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.begin.c']
           expect(lines[5][3]).toEqual value: ')', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.end.c']
-          expect(lines[6][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
-          expect(lines[6][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[6][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[6][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
 
         it 'tokenizes if-true-else blocks', ->
           lines = grammar.tokenizeLines '''
@@ -260,26 +260,26 @@ describe 'Language-C', ->
             }
             #endif
           '''
-          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
-          expect(lines[0][1]).toEqual value: 'if', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[0][1]).toEqual value: 'if', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[0][3]).toEqual value: '1', scopes: ['source.c', 'meta.preprocessor.c', 'constant.numeric.preprocessor.c']
           expect(lines[1][0]).toEqual value: 'int', scopes: ['source.c', 'storage.type.c']
           expect(lines[1][2]).toEqual value: 'something', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
-          expect(lines[2][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
-          expect(lines[2][2]).toEqual value: 'if', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+          expect(lines[2][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[2][2]).toEqual value: 'if', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[2][4]).toEqual value: '1', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'constant.numeric.preprocessor.c']
           expect(lines[3][1]).toEqual value: 'return', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'keyword.control.c']
           expect(lines[3][3]).toEqual value: '1', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'constant.numeric.c']
-          expect(lines[4][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
-          expect(lines[4][2]).toEqual value: 'else', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.else.c']
+          expect(lines[4][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[4][2]).toEqual value: 'else', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[5][0]).toEqual value: '    return 0;', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'comment.block.preprocessor.else-branch.in-block']
-          expect(lines[6][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
-          expect(lines[6][2]).toEqual value: 'endif', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
-          expect(lines[8][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
-          expect(lines[8][1]).toEqual value: 'else', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.else.c']
+          expect(lines[6][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[6][2]).toEqual value: 'endif', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
+          expect(lines[8][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[8][1]).toEqual value: 'else', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[9][0]).toEqual value: 'int something() {', scopes: ['source.c', 'comment.block.preprocessor.else-branch']
-          expect(lines[12][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
-          expect(lines[12][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+          expect(lines[12][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[12][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
 
         it 'tokenizes if-false-else blocks', ->
           lines = grammar.tokenizeLines '''
@@ -293,28 +293,28 @@ describe 'Language-C', ->
           '''
           expect(lines[0][0]).toEqual value: 'int', scopes: ['source.c', 'storage.type.c']
           expect(lines[0][2]).toEqual value: 'something', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
-          expect(lines[1][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
-          expect(lines[1][2]).toEqual value: 'if', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+          expect(lines[1][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[1][2]).toEqual value: 'if', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[1][4]).toEqual value: '0', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'constant.numeric.preprocessor.c']
           expect(lines[2][0]).toEqual value: '    return 1;', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'comment.block.preprocessor.if-branch.in-block']
-          expect(lines[3][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
-          expect(lines[3][2]).toEqual value: 'else', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.else.c']
+          expect(lines[3][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[3][2]).toEqual value: 'else', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[4][1]).toEqual value: 'return', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'keyword.control.c']
           expect(lines[4][3]).toEqual value: '0', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'constant.numeric.c']
-          expect(lines[5][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c']
-          expect(lines[5][2]).toEqual value: 'endif', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+          expect(lines[5][1]).toEqual value: '#', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[5][2]).toEqual value: 'endif', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
 
           lines = grammar.tokenizeLines '''
             #if 0
               something();
             #endif
           '''
-          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
-          expect(lines[0][1]).toEqual value: 'if', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[0][1]).toEqual value: 'if', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[0][3]).toEqual value: '0', scopes: ['source.c', 'meta.preprocessor.c', 'constant.numeric.preprocessor.c']
           expect(lines[1][0]).toEqual value: '  something();', scopes: ['source.c', 'comment.block.preprocessor.if-branch']
-          expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c']
-          expect(lines[2][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.if.c']
+          expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[2][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
 
         it 'tokenizes ifdef-elif blocks', ->
           lines = grammar.tokenizeLines '''
@@ -324,29 +324,30 @@ describe 'Language-C', ->
               # include <windows.h>
             #endif
           '''
-          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
-          expect(lines[0][1]).toEqual value: 'ifdef', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[0][1]).toEqual value: 'ifdef', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[0][2]).toEqual value: ' __unix__ ', scopes: ['source.c', 'meta.preprocessor.c']
           expect(lines[0][3]).toEqual value: '/*', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.begin.c']
           expect(lines[0][4]).toEqual value: ' is defined by compilers targeting Unix systems ', scopes: ['source.c', 'comment.block.c']
           expect(lines[0][5]).toEqual value: '*/', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.end.c']
-          expect(lines[1][1]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c.include", "punctuation.definition.keyword.c"]
-          expect(lines[1][3]).toEqual value: 'include', scopes: ["source.c", "meta.preprocessor.c.include", "keyword.control.import.include.c"]
-          expect(lines[1][5]).toEqual value: '<', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.begin.c"]
-          expect(lines[1][6]).toEqual value: 'unistd.h', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c"]
-          expect(lines[1][7]).toEqual value: '>', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.end.c"]
-          expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
-          expect(lines[2][1]).toEqual value: 'elif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[1][1]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c", "punctuation.definition.directive.c"]
+          expect(lines[1][2]).toEqual value: ' include', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c"]
+          expect(lines[1][4]).toEqual value: '<', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.begin.c"]
+          expect(lines[1][5]).toEqual value: 'unistd.h', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c"]
+          expect(lines[1][6]).toEqual value: '>', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.end.c"]
+          expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[2][1]).toEqual value: 'elif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[2][2]).toEqual value: ' defined _WIN32 ', scopes: ['source.c', 'meta.preprocessor.c']
           expect(lines[2][3]).toEqual value: '/*', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.begin.c']
           expect(lines[2][4]).toEqual value: ' is defined by compilers targeting Windows systems ', scopes: ['source.c', 'comment.block.c']
           expect(lines[2][5]).toEqual value: '*/', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.end.c']
-          expect(lines[3][3]).toEqual value: 'include', scopes: ["source.c", "meta.preprocessor.c.include", "keyword.control.import.include.c"]
-          expect(lines[3][5]).toEqual value: '<', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.begin.c"]
-          expect(lines[3][6]).toEqual value: 'windows.h', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c"]
-          expect(lines[3][7]).toEqual value: '>', scopes: ["source.c", "meta.preprocessor.c.include", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.end.c"]
-          expect(lines[4][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
-          expect(lines[4][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[3][1]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c", "punctuation.definition.directive.c"]
+          expect(lines[3][2]).toEqual value: ' include', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c"]
+          expect(lines[3][4]).toEqual value: '<', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.begin.c"]
+          expect(lines[3][5]).toEqual value: 'windows.h', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c"]
+          expect(lines[3][6]).toEqual value: '>', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.end.c"]
+          expect(lines[4][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[4][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
 
         it 'tokenizes ifndef blocks', ->
           lines = grammar.tokenizeLines '''
@@ -354,14 +355,14 @@ describe 'Language-C', ->
               #define _INCL_GUARD
             #endif
           '''
-          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
-          expect(lines[0][1]).toEqual value: 'ifndef', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[0][1]).toEqual value: 'ifndef', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[0][2]).toEqual value: ' _INCL_GUARD', scopes: ['source.c', 'meta.preprocessor.c']
-          expect(lines[1][1]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.keyword.c"]
-          expect(lines[1][2]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.import.define.c"]
+          expect(lines[1][1]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
+          expect(lines[1][2]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
           expect(lines[1][4]).toEqual value: '_INCL_GUARD', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
-          expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'punctuation.definition.keyword.c']
-          expect(lines[2][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.import.c']
+          expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+          expect(lines[2][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
 
     describe "indentation", ->
       editor = null

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -188,7 +188,7 @@ describe "Language-C", ->
           expect(tokens[4]).toEqual value: 'stdio.h', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c']
           expect(tokens[5]).toEqual value: '>', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c', 'punctuation.definition.string.end.c']
 
-          {tokens} = grammar.tokenizeLine '#include "file">'
+          {tokens} = grammar.tokenizeLine '#include "file"'
           expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c', 'punctuation.definition.directive.c']
           expect(tokens[1]).toEqual value: 'include', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c']
           expect(tokens[3]).toEqual value: '"', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.double.include.c', 'punctuation.definition.string.begin.c']

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -38,20 +38,20 @@ describe "Language-C", ->
       expect(lines[2][0]).toEqual value: '}', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.section.block.end.c']
 
     it "tokenizes various _t types", ->
-      {tokens} = grammar.tokenizeLine('size_t var;')
+      {tokens} = grammar.tokenizeLine 'size_t var;'
       expect(tokens[0]).toEqual value: 'size_t', scopes: ['source.c', 'support.type.sys-types.c']
 
-      {tokens} = grammar.tokenizeLine('pthread_t var;')
+      {tokens} = grammar.tokenizeLine 'pthread_t var;'
       expect(tokens[0]).toEqual value: 'pthread_t', scopes: ['source.c', 'support.type.pthread.c']
 
-      {tokens} = grammar.tokenizeLine('int32_t var;')
+      {tokens} = grammar.tokenizeLine 'int32_t var;'
       expect(tokens[0]).toEqual value: 'int32_t', scopes: ['source.c', 'support.type.stdint.c']
 
-      {tokens} = grammar.tokenizeLine('myType_t var;')
+      {tokens} = grammar.tokenizeLine 'myType_t var;'
       expect(tokens[0]).toEqual value: 'myType_t', scopes: ['source.c', 'support.type.posix-reserved.c']
 
     it "tokenizes 'line continuation' character", ->
-      {tokens} = grammar.tokenizeLine('ma\\\nin(){);')
+      {tokens} = grammar.tokenizeLine 'ma\\\nin(){);'
       expect(tokens[0]).toEqual value: 'ma', scopes: ['source.c']
       expect(tokens[1]).toEqual value: '\\', scopes: ['source.c', 'constant.character.escape.line-continuation.c']
       expect(tokens[3]).toEqual value: 'in', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -6,7 +6,7 @@ buildTextEditor = (params) ->
     TextEditor ?= require('atom').TextEditor
     new TextEditor(params)
 
-describe 'Language-C', ->
+describe "Language-C", ->
   grammar = null
 
   beforeEach ->
@@ -17,143 +17,143 @@ describe 'Language-C', ->
     beforeEach ->
       grammar = atom.grammars.grammarForScopeName('source.c')
 
-    it 'parses the grammar', ->
+    it "parses the grammar", ->
       expect(grammar).toBeTruthy()
       expect(grammar.scopeName).toBe 'source.c'
 
-    it 'tokenizes functions', ->
+    it "tokenizes functions", ->
       lines = grammar.tokenizeLines '''
         int something(int param) {
           return 0;
         }
       '''
-      expect(lines[0][0]).toEqual value: 'int', scopes: ["source.c", "storage.type.c"]
-      expect(lines[0][2]).toEqual value: 'something', scopes: ["source.c", "meta.function.c", "entity.name.function.c"]
-      expect(lines[0][3]).toEqual value: '(', scopes: ["source.c", "meta.function.c", "meta.parens.c", "punctuation.section.parens.begin.c"]
-      expect(lines[0][4]).toEqual value: 'int', scopes: ["source.c", "meta.function.c", "meta.parens.c", "storage.type.c"]
-      expect(lines[0][6]).toEqual value: ')', scopes: ["source.c", "meta.function.c", "meta.parens.c", "punctuation.section.parens.end.c"]
-      expect(lines[0][8]).toEqual value: '{', scopes: ["source.c", "meta.function.c", "meta.block.c", "punctuation.section.block.begin.c"]
-      expect(lines[1][1]).toEqual value: 'return', scopes: ["source.c", "meta.function.c", "meta.block.c", "keyword.control.c"]
-      expect(lines[1][3]).toEqual value: '0', scopes: ["source.c", "meta.function.c", "meta.block.c", "constant.numeric.c"]
-      expect(lines[2][0]).toEqual value: '}', scopes: ["source.c", "meta.function.c", "meta.block.c", "punctuation.section.block.end.c"]
+      expect(lines[0][0]).toEqual value: 'int', scopes: ['source.c', 'storage.type.c']
+      expect(lines[0][2]).toEqual value: 'something', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']
+      expect(lines[0][3]).toEqual value: '(', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.begin.c']
+      expect(lines[0][4]).toEqual value: 'int', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'storage.type.c']
+      expect(lines[0][6]).toEqual value: ')', scopes: ['source.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.end.c']
+      expect(lines[0][8]).toEqual value: '{', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.section.block.begin.c']
+      expect(lines[1][1]).toEqual value: 'return', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'keyword.control.c']
+      expect(lines[1][3]).toEqual value: '0', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'constant.numeric.c']
+      expect(lines[2][0]).toEqual value: '}', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.section.block.end.c']
 
-    it 'tokenizes various _t types', ->
-      {tokens} = grammar.tokenizeLine("size_t var;")
+    it "tokenizes various _t types", ->
+      {tokens} = grammar.tokenizeLine('size_t var;')
       expect(tokens[0]).toEqual value: 'size_t', scopes: ['source.c', 'support.type.sys-types.c']
 
-      {tokens} = grammar.tokenizeLine("pthread_t var;")
+      {tokens} = grammar.tokenizeLine('pthread_t var;')
       expect(tokens[0]).toEqual value: 'pthread_t', scopes: ['source.c', 'support.type.pthread.c']
 
-      {tokens} = grammar.tokenizeLine("int32_t var;")
+      {tokens} = grammar.tokenizeLine('int32_t var;')
       expect(tokens[0]).toEqual value: 'int32_t', scopes: ['source.c', 'support.type.stdint.c']
 
-      {tokens} = grammar.tokenizeLine("myType_t var;")
+      {tokens} = grammar.tokenizeLine('myType_t var;')
       expect(tokens[0]).toEqual value: 'myType_t', scopes: ['source.c', 'support.type.posix-reserved.c']
 
     describe "preprocessor directives", ->
-      it 'tokenizes `#line`', ->
+      it "tokenizes `#line`", ->
         {tokens} = grammar.tokenizeLine '#line 151 "copy.c"'
-        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c", "punctuation.definition.directive.c"]
-        expect(tokens[1]).toEqual value: 'line', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c"]
-        expect(tokens[2]).toEqual value: ' 151 "copy.c"', scopes: ["source.c", "meta.preprocessor.c"]
+        expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c', 'punctuation.definition.directive.c']
+        expect(tokens[1]).toEqual value: 'line', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c']
+        expect(tokens[2]).toEqual value: ' 151 "copy.c"', scopes: ['source.c', 'meta.preprocessor.c']
 
-      it 'tokenizes `#undef`', ->
+      it "tokenizes `#undef`", ->
         {tokens} = grammar.tokenizeLine '#undef FOO'
-        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c", "punctuation.definition.directive.c"]
-        expect(tokens[1]).toEqual value: 'undef', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c"]
-        expect(tokens[2]).toEqual value: ' FOO', scopes: ["source.c", "meta.preprocessor.c"]
+        expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c', 'punctuation.definition.directive.c']
+        expect(tokens[1]).toEqual value: 'undef', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c']
+        expect(tokens[2]).toEqual value: ' FOO', scopes: ['source.c', 'meta.preprocessor.c']
 
-      it 'tokenizes `#pragma`', ->
+      it "tokenizes `#pragma`", ->
         {tokens} = grammar.tokenizeLine '#pragma once'
-        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c", "punctuation.definition.directive.c"]
-        expect(tokens[1]).toEqual value: 'pragma', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c"]
-        expect(tokens[2]).toEqual value: ' once', scopes: ["source.c", "meta.preprocessor.c"]
+        expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c', 'punctuation.definition.directive.c']
+        expect(tokens[1]).toEqual value: 'pragma', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c']
+        expect(tokens[2]).toEqual value: ' once', scopes: ['source.c', 'meta.preprocessor.c']
 
         {tokens} = grammar.tokenizeLine '#pragma clang diagnostic push'
-        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c", "punctuation.definition.directive.c"]
-        expect(tokens[1]).toEqual value: 'pragma', scopes: ["source.c", "meta.preprocessor.c", "keyword.control.directive.c"]
-        expect(tokens[2]).toEqual value: ' clang diagnostic push', scopes: ["source.c", "meta.preprocessor.c"]
+        expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c', 'punctuation.definition.directive.c']
+        expect(tokens[1]).toEqual value: 'pragma', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c']
+        expect(tokens[2]).toEqual value: ' clang diagnostic push', scopes: ['source.c', 'meta.preprocessor.c']
 
         {tokens} = grammar.tokenizeLine '#pragma mark – Initialization'
-        expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.section", "meta.preprocessor.c", "keyword.control.directive.pragma.pragma-mark.c",  "punctuation.definition.directive.c"]
-        expect(tokens[1]).toEqual value: 'pragma mark', scopes: ["source.c", "meta.section",  "meta.preprocessor.c", "keyword.control.directive.pragma.pragma-mark.c"]
-        expect(tokens[3]).toEqual value: '– Initialization', scopes: ["source.c", "meta.section",  "meta.preprocessor.c", "meta.toc-list.pragma-mark.c"]
+        expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.section', 'meta.preprocessor.c', 'keyword.control.directive.pragma.pragma-mark.c',  'punctuation.definition.directive.c']
+        expect(tokens[1]).toEqual value: 'pragma mark', scopes: ['source.c', 'meta.section',  'meta.preprocessor.c', 'keyword.control.directive.pragma.pragma-mark.c']
+        expect(tokens[3]).toEqual value: '– Initialization', scopes: ['source.c', 'meta.section',  'meta.preprocessor.c', 'meta.toc-list.pragma-mark.c']
 
       describe "define", ->
-        it 'tokenizes `#define [identifier name]`', ->
+        it "tokenizes `#define [identifier name]`", ->
           {tokens} = grammar.tokenizeLine '#define _FILE_NAME_H_'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
-          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
-          expect(tokens[3]).toEqual value: '_FILE_NAME_H_', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c', 'punctuation.definition.directive.c']
+          expect(tokens[1]).toEqual value: 'define', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c']
+          expect(tokens[3]).toEqual value: '_FILE_NAME_H_', scopes: ['source.c', 'meta.preprocessor.macro.c', 'entity.name.function.preprocessor.c']
 
-        it 'tokenizes `#define [identifier name] [value]`', ->
+        it "tokenizes `#define [identifier name] [value]`", ->
           {tokens} = grammar.tokenizeLine '#define WIDTH 80'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
-          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
-          expect(tokens[3]).toEqual value: 'WIDTH', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
-          expect(tokens[5]).toEqual value: '80', scopes: ["source.c", "meta.preprocessor.macro.c", "constant.numeric.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c', 'punctuation.definition.directive.c']
+          expect(tokens[1]).toEqual value: 'define', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c']
+          expect(tokens[3]).toEqual value: 'WIDTH', scopes: ['source.c', 'meta.preprocessor.macro.c', 'entity.name.function.preprocessor.c']
+          expect(tokens[5]).toEqual value: '80', scopes: ['source.c', 'meta.preprocessor.macro.c', 'constant.numeric.c']
 
           {tokens} = grammar.tokenizeLine '#define ABC XYZ(1)'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
-          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
-          expect(tokens[3]).toEqual value: 'ABC', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
-          expect(tokens[4]).toEqual value: ' ', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.function.c", "punctuation.whitespace.function.leading.c"]
-          expect(tokens[5]).toEqual value: 'XYZ', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.function.c", "entity.name.function.c"]
-          expect(tokens[6]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.function.c", "meta.parens.c", "punctuation.section.parens.begin.c"]
-          expect(tokens[7]).toEqual value: '1', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.function.c", "meta.parens.c", "constant.numeric.c"]
-          expect(tokens[8]).toEqual value: ')', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.function.c", "meta.parens.c", "punctuation.section.parens.end.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c', 'punctuation.definition.directive.c']
+          expect(tokens[1]).toEqual value: 'define', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c']
+          expect(tokens[3]).toEqual value: 'ABC', scopes: ['source.c', 'meta.preprocessor.macro.c', 'entity.name.function.preprocessor.c']
+          expect(tokens[4]).toEqual value: ' ', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.function.c', 'punctuation.whitespace.function.leading.c']
+          expect(tokens[5]).toEqual value: 'XYZ', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.function.c', 'entity.name.function.c']
+          expect(tokens[6]).toEqual value: '(', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.begin.c']
+          expect(tokens[7]).toEqual value: '1', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.function.c', 'meta.parens.c', 'constant.numeric.c']
+          expect(tokens[8]).toEqual value: ')', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.function.c', 'meta.parens.c', 'punctuation.section.parens.end.c']
 
           {tokens} = grammar.tokenizeLine '#define PI_PLUS_ONE (3.14 + 1)'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
-          expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
-          expect(tokens[3]).toEqual value: 'PI_PLUS_ONE', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
-          expect(tokens[4]).toEqual value: ' (', scopes: ["source.c", "meta.preprocessor.macro.c"]
-          expect(tokens[5]).toEqual value: '3.14', scopes: ["source.c", "meta.preprocessor.macro.c", "constant.numeric.c"]
-          expect(tokens[6]).toEqual value: ' + ', scopes: ["source.c", "meta.preprocessor.macro.c"]
-          expect(tokens[7]).toEqual value: '1', scopes: ["source.c", "meta.preprocessor.macro.c", "constant.numeric.c"]
-          expect(tokens[8]).toEqual value: ')', scopes: ["source.c", "meta.preprocessor.macro.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c', 'punctuation.definition.directive.c']
+          expect(tokens[1]).toEqual value: 'define', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c']
+          expect(tokens[3]).toEqual value: 'PI_PLUS_ONE', scopes: ['source.c', 'meta.preprocessor.macro.c', 'entity.name.function.preprocessor.c']
+          expect(tokens[4]).toEqual value: ' (', scopes: ['source.c', 'meta.preprocessor.macro.c']
+          expect(tokens[5]).toEqual value: '3.14', scopes: ['source.c', 'meta.preprocessor.macro.c', 'constant.numeric.c']
+          expect(tokens[6]).toEqual value: ' + ', scopes: ['source.c', 'meta.preprocessor.macro.c']
+          expect(tokens[7]).toEqual value: '1', scopes: ['source.c', 'meta.preprocessor.macro.c', 'constant.numeric.c']
+          expect(tokens[8]).toEqual value: ')', scopes: ['source.c', 'meta.preprocessor.macro.c']
 
         describe "macros", ->
-          it 'tokenizes them', ->
+          it "tokenizes them", ->
             {tokens} = grammar.tokenizeLine '#define INCREMENT(x) x++'
-            expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
-            expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
-            expect(tokens[3]).toEqual value: 'INCREMENT', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
-            expect(tokens[4]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.begin.c"]
-            expect(tokens[5]).toEqual value: 'x', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
-            expect(tokens[6]).toEqual value: ')', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.end.c"]
-            expect(tokens[7]).toEqual value: ' x++', scopes: ["source.c", "meta.preprocessor.macro.c"]
+            expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c', 'punctuation.definition.directive.c']
+            expect(tokens[1]).toEqual value: 'define', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c']
+            expect(tokens[3]).toEqual value: 'INCREMENT', scopes: ['source.c', 'meta.preprocessor.macro.c', 'entity.name.function.preprocessor.c']
+            expect(tokens[4]).toEqual value: '(', scopes: ['source.c', 'meta.preprocessor.macro.c', 'punctuation.definition.parameters.begin.c']
+            expect(tokens[5]).toEqual value: 'x', scopes: ['source.c', 'meta.preprocessor.macro.c', 'variable.parameter.preprocessor.c']
+            expect(tokens[6]).toEqual value: ')', scopes: ['source.c', 'meta.preprocessor.macro.c', 'punctuation.definition.parameters.end.c']
+            expect(tokens[7]).toEqual value: ' x++', scopes: ['source.c', 'meta.preprocessor.macro.c']
 
             {tokens} = grammar.tokenizeLine '#define MULT(x, y) (x) * (y)'
-            expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
-            expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
-            expect(tokens[3]).toEqual value: 'MULT', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
-            expect(tokens[4]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.begin.c"]
-            expect(tokens[5]).toEqual value: 'x', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
-            expect(tokens[6]).toEqual value: ',', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c", "punctuation.separator.parameters.c"]
-            expect(tokens[7]).toEqual value: ' y', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
-            expect(tokens[8]).toEqual value: ')', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.end.c"]
-            expect(tokens[9]).toEqual value: ' (x) * (y)', scopes: ["source.c", "meta.preprocessor.macro.c"]
+            expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c', 'punctuation.definition.directive.c']
+            expect(tokens[1]).toEqual value: 'define', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c']
+            expect(tokens[3]).toEqual value: 'MULT', scopes: ['source.c', 'meta.preprocessor.macro.c', 'entity.name.function.preprocessor.c']
+            expect(tokens[4]).toEqual value: '(', scopes: ['source.c', 'meta.preprocessor.macro.c', 'punctuation.definition.parameters.begin.c']
+            expect(tokens[5]).toEqual value: 'x', scopes: ['source.c', 'meta.preprocessor.macro.c', 'variable.parameter.preprocessor.c']
+            expect(tokens[6]).toEqual value: ',', scopes: ['source.c', 'meta.preprocessor.macro.c', 'variable.parameter.preprocessor.c', 'punctuation.separator.parameters.c']
+            expect(tokens[7]).toEqual value: ' y', scopes: ['source.c', 'meta.preprocessor.macro.c', 'variable.parameter.preprocessor.c']
+            expect(tokens[8]).toEqual value: ')', scopes: ['source.c', 'meta.preprocessor.macro.c', 'punctuation.definition.parameters.end.c']
+            expect(tokens[9]).toEqual value: ' (x) * (y)', scopes: ['source.c', 'meta.preprocessor.macro.c']
 
             {tokens} = grammar.tokenizeLine '#define SWAP(a, b)  do { a ^= b; b ^= a; a ^= b; } while ( 0 )'
-            expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
-            expect(tokens[1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
-            expect(tokens[3]).toEqual value: 'SWAP', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
-            expect(tokens[4]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.begin.c"]
-            expect(tokens[5]).toEqual value: 'a', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
-            expect(tokens[6]).toEqual value: ',', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c", "punctuation.separator.parameters.c"]
-            expect(tokens[7]).toEqual value: ' b', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
-            expect(tokens[8]).toEqual value: ')', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.end.c"]
-            expect(tokens[10]).toEqual value: 'do', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.c"]
-            expect(tokens[12]).toEqual value: '{', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c", "punctuation.section.block.begin.c"]
-            expect(tokens[13]).toEqual value: ' a ^= b; b ^= a; a ^= b; ', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c"]
-            expect(tokens[14]).toEqual value: '}', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c", "punctuation.section.block.end.c"]
-            expect(tokens[16]).toEqual value: 'while', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.c"]
-            expect(tokens[17]).toEqual value: ' ( ', scopes: ["source.c", "meta.preprocessor.macro.c"]
-            expect(tokens[18]).toEqual value: '0', scopes: ["source.c", "meta.preprocessor.macro.c", "constant.numeric.c"]
-            expect(tokens[19]).toEqual value: ' )', scopes: ["source.c", "meta.preprocessor.macro.c"]
+            expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c', 'punctuation.definition.directive.c']
+            expect(tokens[1]).toEqual value: 'define', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c']
+            expect(tokens[3]).toEqual value: 'SWAP', scopes: ['source.c', 'meta.preprocessor.macro.c', 'entity.name.function.preprocessor.c']
+            expect(tokens[4]).toEqual value: '(', scopes: ['source.c', 'meta.preprocessor.macro.c', 'punctuation.definition.parameters.begin.c']
+            expect(tokens[5]).toEqual value: 'a', scopes: ['source.c', 'meta.preprocessor.macro.c', 'variable.parameter.preprocessor.c']
+            expect(tokens[6]).toEqual value: ',', scopes: ['source.c', 'meta.preprocessor.macro.c', 'variable.parameter.preprocessor.c', 'punctuation.separator.parameters.c']
+            expect(tokens[7]).toEqual value: ' b', scopes: ['source.c', 'meta.preprocessor.macro.c', 'variable.parameter.preprocessor.c']
+            expect(tokens[8]).toEqual value: ')', scopes: ['source.c', 'meta.preprocessor.macro.c', 'punctuation.definition.parameters.end.c']
+            expect(tokens[10]).toEqual value: 'do', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.c']
+            expect(tokens[12]).toEqual value: '{', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.block.c', 'punctuation.section.block.begin.c']
+            expect(tokens[13]).toEqual value: ' a ^= b; b ^= a; a ^= b; ', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.block.c']
+            expect(tokens[14]).toEqual value: '}', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.block.c', 'punctuation.section.block.end.c']
+            expect(tokens[16]).toEqual value: 'while', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.c']
+            expect(tokens[17]).toEqual value: ' ( ', scopes: ['source.c', 'meta.preprocessor.macro.c']
+            expect(tokens[18]).toEqual value: '0', scopes: ['source.c', 'meta.preprocessor.macro.c', 'constant.numeric.c']
+            expect(tokens[19]).toEqual value: ' )', scopes: ['source.c', 'meta.preprocessor.macro.c']
 
-          it 'tokenizes multiline macros', ->
+          it "tokenizes multiline macros", ->
             lines = grammar.tokenizeLines '''
               #define SWAP(a, b)  { \\
                 a ^= b; \\
@@ -161,60 +161,60 @@ describe 'Language-C', ->
                 a ^= b; \\
               }
             '''
-            expect(lines[0][0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
-            expect(lines[0][1]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
-            expect(lines[0][3]).toEqual value: 'SWAP', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
-            expect(lines[0][4]).toEqual value: '(', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.begin.c"]
-            expect(lines[0][5]).toEqual value: 'a', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
-            expect(lines[0][6]).toEqual value: ',', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c", "punctuation.separator.parameters.c"]
-            expect(lines[0][7]).toEqual value: ' b', scopes: ["source.c", "meta.preprocessor.macro.c", "variable.parameter.preprocessor.c"]
-            expect(lines[0][8]).toEqual value: ')', scopes: ["source.c", "meta.preprocessor.macro.c", "punctuation.definition.parameters.end.c"]
-            expect(lines[0][10]).toEqual value: '{', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c", "punctuation.section.block.begin.c"]
-            expect(lines[0][11]).toEqual value: ' \\', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c"]
-            expect(lines[1][0]).toEqual value: '  a ^= b; \\', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c"]
-            expect(lines[2][0]).toEqual value: '  b ^= a; \\', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c"]
-            expect(lines[3][0]).toEqual value: '  a ^= b; \\', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c"]
-            expect(lines[4][0]).toEqual value: '}', scopes: ["source.c", "meta.preprocessor.macro.c", "meta.block.c", "punctuation.section.block.end.c"]
+            expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c', 'punctuation.definition.directive.c']
+            expect(lines[0][1]).toEqual value: 'define', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c']
+            expect(lines[0][3]).toEqual value: 'SWAP', scopes: ['source.c', 'meta.preprocessor.macro.c', 'entity.name.function.preprocessor.c']
+            expect(lines[0][4]).toEqual value: '(', scopes: ['source.c', 'meta.preprocessor.macro.c', 'punctuation.definition.parameters.begin.c']
+            expect(lines[0][5]).toEqual value: 'a', scopes: ['source.c', 'meta.preprocessor.macro.c', 'variable.parameter.preprocessor.c']
+            expect(lines[0][6]).toEqual value: ',', scopes: ['source.c', 'meta.preprocessor.macro.c', 'variable.parameter.preprocessor.c', 'punctuation.separator.parameters.c']
+            expect(lines[0][7]).toEqual value: ' b', scopes: ['source.c', 'meta.preprocessor.macro.c', 'variable.parameter.preprocessor.c']
+            expect(lines[0][8]).toEqual value: ')', scopes: ['source.c', 'meta.preprocessor.macro.c', 'punctuation.definition.parameters.end.c']
+            expect(lines[0][10]).toEqual value: '{', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.block.c', 'punctuation.section.block.begin.c']
+            expect(lines[0][11]).toEqual value: ' \\', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.block.c']
+            expect(lines[1][0]).toEqual value: '  a ^= b; \\', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.block.c']
+            expect(lines[2][0]).toEqual value: '  b ^= a; \\', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.block.c']
+            expect(lines[3][0]).toEqual value: '  a ^= b; \\', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.block.c']
+            expect(lines[4][0]).toEqual value: '}', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.block.c', 'punctuation.section.block.end.c']
 
-      describe 'includes', ->
-        it 'tokenizes `#include`', ->
+      describe "includes", ->
+        it "tokenizes `#include`", ->
           {tokens} = grammar.tokenizeLine '#include <stdio.h>'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c", "punctuation.definition.directive.c"]
-          expect(tokens[1]).toEqual value: 'include', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c"]
-          expect(tokens[3]).toEqual value: '<', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.begin.c"]
-          expect(tokens[4]).toEqual value: 'stdio.h', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c"]
-          expect(tokens[5]).toEqual value: '>', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.end.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c', 'punctuation.definition.directive.c']
+          expect(tokens[1]).toEqual value: 'include', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c']
+          expect(tokens[3]).toEqual value: '<', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c', 'punctuation.definition.string.begin.c']
+          expect(tokens[4]).toEqual value: 'stdio.h', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c']
+          expect(tokens[5]).toEqual value: '>', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c', 'punctuation.definition.string.end.c']
 
           {tokens} = grammar.tokenizeLine '#include "file">'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c", "punctuation.definition.directive.c"]
-          expect(tokens[1]).toEqual value: 'include', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c"]
-          expect(tokens[3]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.double.include.c", "punctuation.definition.string.begin.c"]
-          expect(tokens[4]).toEqual value: 'file', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.double.include.c"]
-          expect(tokens[5]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.double.include.c", "punctuation.definition.string.end.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c', 'punctuation.definition.directive.c']
+          expect(tokens[1]).toEqual value: 'include', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c']
+          expect(tokens[3]).toEqual value: '"', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.double.include.c', 'punctuation.definition.string.begin.c']
+          expect(tokens[4]).toEqual value: 'file', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.double.include.c']
+          expect(tokens[5]).toEqual value: '"', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.double.include.c', 'punctuation.definition.string.end.c']
 
-        it 'tokenizes `#import`', ->
+        it "tokenizes `#import`", ->
           {tokens} = grammar.tokenizeLine '#import "file"'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.import.c", "punctuation.definition.directive.c"]
-          expect(tokens[1]).toEqual value: 'import', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.import.c"]
-          expect(tokens[3]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.double.include.c", "punctuation.definition.string.begin.c"]
-          expect(tokens[4]).toEqual value: 'file', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.double.include.c"]
-          expect(tokens[5]).toEqual value: '"', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.double.include.c", "punctuation.definition.string.end.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.import.c', 'punctuation.definition.directive.c']
+          expect(tokens[1]).toEqual value: 'import', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.import.c']
+          expect(tokens[3]).toEqual value: '"', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.double.include.c', 'punctuation.definition.string.begin.c']
+          expect(tokens[4]).toEqual value: 'file', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.double.include.c']
+          expect(tokens[5]).toEqual value: '"', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.double.include.c', 'punctuation.definition.string.end.c']
 
-      describe 'diagnostics', ->
-        it 'tokenizes `#error`', ->
+      describe "diagnostics", ->
+        it "tokenizes `#error`", ->
           {tokens} = grammar.tokenizeLine '#error C++ compiler required.'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "keyword.control.directive.diagnostic.error.c", "punctuation.definition.directive.c"]
-          expect(tokens[1]).toEqual value: 'error', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "keyword.control.directive.diagnostic.error.c"]
-          expect(tokens[2]).toEqual value: ' C++ compiler required.', scopes: ["source.c", "meta.preprocessor.diagnostic.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.diagnostic.c', 'keyword.control.directive.diagnostic.error.c', 'punctuation.definition.directive.c']
+          expect(tokens[1]).toEqual value: 'error', scopes: ['source.c', 'meta.preprocessor.diagnostic.c', 'keyword.control.directive.diagnostic.error.c']
+          expect(tokens[2]).toEqual value: ' C++ compiler required.', scopes: ['source.c', 'meta.preprocessor.diagnostic.c']
 
-        it 'tokenizes `#warning`', ->
+        it "tokenizes `#warning`", ->
           {tokens} = grammar.tokenizeLine '#warning This is a warning.'
-          expect(tokens[0]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "keyword.control.directive.diagnostic.warning.c", "punctuation.definition.directive.c"]
-          expect(tokens[1]).toEqual value: 'warning', scopes: ["source.c", "meta.preprocessor.diagnostic.c", "keyword.control.directive.diagnostic.warning.c"]
-          expect(tokens[2]).toEqual value: ' This is a warning.', scopes: ["source.c", "meta.preprocessor.diagnostic.c"]
+          expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.diagnostic.c', 'keyword.control.directive.diagnostic.warning.c', 'punctuation.definition.directive.c']
+          expect(tokens[1]).toEqual value: 'warning', scopes: ['source.c', 'meta.preprocessor.diagnostic.c', 'keyword.control.directive.diagnostic.warning.c']
+          expect(tokens[2]).toEqual value: ' This is a warning.', scopes: ['source.c', 'meta.preprocessor.diagnostic.c']
 
-      describe 'conditionals', ->
-        it 'tokenizes if-elif-else preprocessor blocks', ->
+      describe "conditionals", ->
+        it "tokenizes if-elif-else preprocessor blocks", ->
           lines = grammar.tokenizeLines '''
             #if defined(CREDIT)
                 credit();
@@ -244,7 +244,7 @@ describe 'Language-C', ->
           expect(lines[6][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
           expect(lines[6][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
 
-        it 'tokenizes if-true-else blocks', ->
+        it "tokenizes if-true-else blocks", ->
           lines = grammar.tokenizeLines '''
             #if 1
             int something() {
@@ -281,7 +281,7 @@ describe 'Language-C', ->
           expect(lines[12][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
           expect(lines[12][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
 
-        it 'tokenizes if-false-else blocks', ->
+        it "tokenizes if-false-else blocks", ->
           lines = grammar.tokenizeLines '''
             int something() {
               #if 0
@@ -316,7 +316,7 @@ describe 'Language-C', ->
           expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
           expect(lines[2][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
 
-        it 'tokenizes ifdef-elif blocks', ->
+        it "tokenizes ifdef-elif blocks", ->
           lines = grammar.tokenizeLines '''
             #ifdef __unix__ /* is defined by compilers targeting Unix systems */
               # include <unistd.h>
@@ -330,26 +330,26 @@ describe 'Language-C', ->
           expect(lines[0][3]).toEqual value: '/*', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.begin.c']
           expect(lines[0][4]).toEqual value: ' is defined by compilers targeting Unix systems ', scopes: ['source.c', 'comment.block.c']
           expect(lines[0][5]).toEqual value: '*/', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.end.c']
-          expect(lines[1][1]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c", "punctuation.definition.directive.c"]
-          expect(lines[1][2]).toEqual value: ' include', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c"]
-          expect(lines[1][4]).toEqual value: '<', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.begin.c"]
-          expect(lines[1][5]).toEqual value: 'unistd.h', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c"]
-          expect(lines[1][6]).toEqual value: '>', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.end.c"]
+          expect(lines[1][1]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c', 'punctuation.definition.directive.c']
+          expect(lines[1][2]).toEqual value: ' include', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c']
+          expect(lines[1][4]).toEqual value: '<', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c', 'punctuation.definition.string.begin.c']
+          expect(lines[1][5]).toEqual value: 'unistd.h', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c']
+          expect(lines[1][6]).toEqual value: '>', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c', 'punctuation.definition.string.end.c']
           expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
           expect(lines[2][1]).toEqual value: 'elif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[2][2]).toEqual value: ' defined _WIN32 ', scopes: ['source.c', 'meta.preprocessor.c']
           expect(lines[2][3]).toEqual value: '/*', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.begin.c']
           expect(lines[2][4]).toEqual value: ' is defined by compilers targeting Windows systems ', scopes: ['source.c', 'comment.block.c']
           expect(lines[2][5]).toEqual value: '*/', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.end.c']
-          expect(lines[3][1]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c", "punctuation.definition.directive.c"]
-          expect(lines[3][2]).toEqual value: ' include', scopes: ["source.c", "meta.preprocessor.include.c", "keyword.control.directive.include.c"]
-          expect(lines[3][4]).toEqual value: '<', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.begin.c"]
-          expect(lines[3][5]).toEqual value: 'windows.h', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c"]
-          expect(lines[3][6]).toEqual value: '>', scopes: ["source.c", "meta.preprocessor.include.c", "string.quoted.other.lt-gt.include.c", "punctuation.definition.string.end.c"]
+          expect(lines[3][1]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c', 'punctuation.definition.directive.c']
+          expect(lines[3][2]).toEqual value: ' include', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c']
+          expect(lines[3][4]).toEqual value: '<', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c', 'punctuation.definition.string.begin.c']
+          expect(lines[3][5]).toEqual value: 'windows.h', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c']
+          expect(lines[3][6]).toEqual value: '>', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.other.lt-gt.include.c', 'punctuation.definition.string.end.c']
           expect(lines[4][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
           expect(lines[4][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
 
-        it 'tokenizes ifndef blocks', ->
+        it "tokenizes ifndef blocks", ->
           lines = grammar.tokenizeLines '''
             #ifndef _INCL_GUARD
               #define _INCL_GUARD
@@ -358,9 +358,9 @@ describe 'Language-C', ->
           expect(lines[0][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
           expect(lines[0][1]).toEqual value: 'ifndef', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
           expect(lines[0][2]).toEqual value: ' _INCL_GUARD', scopes: ['source.c', 'meta.preprocessor.c']
-          expect(lines[1][1]).toEqual value: '#', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c", "punctuation.definition.directive.c"]
-          expect(lines[1][2]).toEqual value: 'define', scopes: ["source.c", "meta.preprocessor.macro.c", "keyword.control.directive.define.c"]
-          expect(lines[1][4]).toEqual value: '_INCL_GUARD', scopes: ["source.c", "meta.preprocessor.macro.c", "entity.name.function.preprocessor.c"]
+          expect(lines[1][1]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c', 'punctuation.definition.directive.c']
+          expect(lines[1][2]).toEqual value: 'define', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c']
+          expect(lines[1][4]).toEqual value: '_INCL_GUARD', scopes: ['source.c', 'meta.preprocessor.macro.c', 'entity.name.function.preprocessor.c']
           expect(lines[2][0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
           expect(lines[2][1]).toEqual value: 'endif', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
 
@@ -375,8 +375,8 @@ describe 'Language-C', ->
         editor.setText(text)
         editor.autoIndentBufferRows(0, editor.getLineCount() - 1)
 
-        expectedLines = text.split("\n")
-        actualLines = editor.getText().split("\n")
+        expectedLines = text.split('\n')
+        actualLines = editor.getText().split('\n')
         for actualLine, i in actualLines
           expect([
             actualLine,
@@ -387,7 +387,7 @@ describe 'Language-C', ->
           ])
 
       it "indents allman-style curly braces", ->
-        expectPreservedIndentation """
+        expectPreservedIndentation '''
           if (a)
           {
             for (;;)
@@ -402,10 +402,10 @@ describe 'Language-C', ->
               while (d)
             }
           }
-        """
+        '''
 
       it "indents non-allman-style curly braces", ->
-        expectPreservedIndentation """
+        expectPreservedIndentation '''
           if (a) {
             for (;;) {
               do {
@@ -415,43 +415,43 @@ describe 'Language-C', ->
               } while (d)
             }
           }
-        """
+        '''
 
       it "indents function arguments", ->
-        expectPreservedIndentation """
+        expectPreservedIndentation '''
           a(
             b,
             c(
               d
             )
           );
-        """
+        '''
 
       it "indents array and struct literals", ->
-        expectPreservedIndentation """
+        expectPreservedIndentation '''
           some_t a[3] = {
             { .b = c },
             { .b = c, .d = {1, 2} },
           };
-        """
+        '''
 
   describe "C++", ->
     beforeEach ->
       grammar = atom.grammars.grammarForScopeName('source.cpp')
 
-    it 'parses the grammar', ->
+    it "parses the grammar", ->
       expect(grammar).toBeTruthy()
       expect(grammar.scopeName).toBe 'source.cpp'
 
-    it 'tokenizes this with `.this` class', ->
+    it "tokenizes this with `.this` class", ->
       {tokens} = grammar.tokenizeLine 'this.x'
       expect(tokens[0]).toEqual value: 'this', scopes: ['source.cpp', 'variable.language.this.cpp']
 
-    it 'tokenizes classes', ->
+    it "tokenizes classes", ->
       lines = grammar.tokenizeLines '''
         class Thing {
           int x;
         }
       '''
-      expect(lines[0][0]).toEqual value: 'class', scopes: ["source.cpp", "meta.class-struct-block.cpp", "storage.type.cpp"]
-      expect(lines[0][2]).toEqual value: 'Thing', scopes: ["source.cpp", "meta.class-struct-block.cpp", "entity.name.type.cpp"]
+      expect(lines[0][0]).toEqual value: 'class', scopes: ['source.cpp', 'meta.class-struct-block.cpp', 'storage.type.cpp']
+      expect(lines[0][2]).toEqual value: 'Thing', scopes: ['source.cpp', 'meta.class-struct-block.cpp', 'entity.name.type.cpp']

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -51,19 +51,19 @@ describe "Language-C", ->
       expect(tokens[0]).toEqual value: 'myType_t', scopes: ['source.c', 'support.type.posix-reserved.c']
 
     describe "preprocessor directives", ->
-      it "tokenizes `#line`", ->
+      it "tokenizes '#line'", ->
         {tokens} = grammar.tokenizeLine '#line 151 "copy.c"'
         expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c', 'punctuation.definition.directive.c']
         expect(tokens[1]).toEqual value: 'line', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c']
         expect(tokens[2]).toEqual value: ' 151 "copy.c"', scopes: ['source.c', 'meta.preprocessor.c']
 
-      it "tokenizes `#undef`", ->
+      it "tokenizes '#undef'", ->
         {tokens} = grammar.tokenizeLine '#undef FOO'
         expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c', 'punctuation.definition.directive.c']
         expect(tokens[1]).toEqual value: 'undef', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c']
         expect(tokens[2]).toEqual value: ' FOO', scopes: ['source.c', 'meta.preprocessor.c']
 
-      it "tokenizes `#pragma`", ->
+      it "tokenizes '#pragma'", ->
         {tokens} = grammar.tokenizeLine '#pragma once'
         expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c', 'punctuation.definition.directive.c']
         expect(tokens[1]).toEqual value: 'pragma', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c']
@@ -80,13 +80,13 @@ describe "Language-C", ->
         expect(tokens[3]).toEqual value: '– Initialization', scopes: ['source.c', 'meta.section',  'meta.preprocessor.c', 'meta.toc-list.pragma-mark.c']
 
       describe "define", ->
-        it "tokenizes `#define [identifier name]`", ->
+        it "tokenizes '#define [identifier name]'", ->
           {tokens} = grammar.tokenizeLine '#define _FILE_NAME_H_'
           expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c', 'punctuation.definition.directive.c']
           expect(tokens[1]).toEqual value: 'define', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c']
           expect(tokens[3]).toEqual value: '_FILE_NAME_H_', scopes: ['source.c', 'meta.preprocessor.macro.c', 'entity.name.function.preprocessor.c']
 
-        it "tokenizes `#define [identifier name] [value]`", ->
+        it "tokenizes '#define [identifier name] [value]'", ->
           {tokens} = grammar.tokenizeLine '#define WIDTH 80'
           expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c', 'punctuation.definition.directive.c']
           expect(tokens[1]).toEqual value: 'define', scopes: ['source.c', 'meta.preprocessor.macro.c', 'keyword.control.directive.define.c']
@@ -177,7 +177,7 @@ describe "Language-C", ->
             expect(lines[4][0]).toEqual value: '}', scopes: ['source.c', 'meta.preprocessor.macro.c', 'meta.block.c', 'punctuation.section.block.end.c']
 
       describe "includes", ->
-        it "tokenizes `#include`", ->
+        it "tokenizes '#include'", ->
           {tokens} = grammar.tokenizeLine '#include <stdio.h>'
           expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c', 'punctuation.definition.directive.c']
           expect(tokens[1]).toEqual value: 'include', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c']
@@ -192,7 +192,7 @@ describe "Language-C", ->
           expect(tokens[4]).toEqual value: 'file', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.double.include.c']
           expect(tokens[5]).toEqual value: '"', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.double.include.c', 'punctuation.definition.string.end.c']
 
-        it "tokenizes `#import`", ->
+        it "tokenizes '#import'", ->
           {tokens} = grammar.tokenizeLine '#import "file"'
           expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.import.c', 'punctuation.definition.directive.c']
           expect(tokens[1]).toEqual value: 'import', scopes: ['source.c', 'meta.preprocessor.include.c', 'keyword.control.directive.import.c']
@@ -201,13 +201,13 @@ describe "Language-C", ->
           expect(tokens[5]).toEqual value: '"', scopes: ['source.c', 'meta.preprocessor.include.c', 'string.quoted.double.include.c', 'punctuation.definition.string.end.c']
 
       describe "diagnostics", ->
-        it "tokenizes `#error`", ->
+        it "tokenizes '#error'", ->
           {tokens} = grammar.tokenizeLine '#error C++ compiler required.'
           expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.diagnostic.c', 'keyword.control.directive.diagnostic.error.c', 'punctuation.definition.directive.c']
           expect(tokens[1]).toEqual value: 'error', scopes: ['source.c', 'meta.preprocessor.diagnostic.c', 'keyword.control.directive.diagnostic.error.c']
           expect(tokens[2]).toEqual value: ' C++ compiler required.', scopes: ['source.c', 'meta.preprocessor.diagnostic.c']
 
-        it "tokenizes `#warning`", ->
+        it "tokenizes '#warning'", ->
           {tokens} = grammar.tokenizeLine '#warning This is a warning.'
           expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.diagnostic.c', 'keyword.control.directive.diagnostic.warning.c', 'punctuation.definition.directive.c']
           expect(tokens[1]).toEqual value: 'warning', scopes: ['source.c', 'meta.preprocessor.diagnostic.c', 'keyword.control.directive.diagnostic.warning.c']

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -62,19 +62,19 @@ describe "Language-C", ->
 
       it "tokenizes '#undef'", ->
         {tokens} = grammar.tokenizeLine '#undef FOO'
-        expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c', 'punctuation.definition.directive.c']
-        expect(tokens[1]).toEqual value: 'undef', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c']
+        expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.undef.c', 'punctuation.definition.directive.c']
+        expect(tokens[1]).toEqual value: 'undef', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.undef.c']
         expect(tokens[2]).toEqual value: ' FOO', scopes: ['source.c', 'meta.preprocessor.c']
 
       it "tokenizes '#pragma'", ->
         {tokens} = grammar.tokenizeLine '#pragma once'
-        expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c', 'punctuation.definition.directive.c']
-        expect(tokens[1]).toEqual value: 'pragma', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c']
+        expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.pragma.c', 'punctuation.definition.directive.c']
+        expect(tokens[1]).toEqual value: 'pragma', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.pragma.c']
         expect(tokens[2]).toEqual value: ' once', scopes: ['source.c', 'meta.preprocessor.c']
 
         {tokens} = grammar.tokenizeLine '#pragma clang diagnostic push'
-        expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c', 'punctuation.definition.directive.c']
-        expect(tokens[1]).toEqual value: 'pragma', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.c']
+        expect(tokens[0]).toEqual value: '#', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.pragma.c', 'punctuation.definition.directive.c']
+        expect(tokens[1]).toEqual value: 'pragma', scopes: ['source.c', 'meta.preprocessor.c', 'keyword.control.directive.pragma.c']
         expect(tokens[2]).toEqual value: ' clang diagnostic push', scopes: ['source.c', 'meta.preprocessor.c']
 
         {tokens} = grammar.tokenizeLine '#pragma mark – Initialization'

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -517,6 +517,51 @@ describe "Language-C", ->
       expect(lines[0][0]).toEqual value: 'class', scopes: ['source.cpp', 'meta.class-struct-block.cpp', 'storage.type.cpp']
       expect(lines[0][2]).toEqual value: 'Thing', scopes: ['source.cpp', 'meta.class-struct-block.cpp', 'entity.name.type.cpp']
 
+    it "tokenizes 'extern C'", ->
+      lines = grammar.tokenizeLines '''
+        extern "C" {
+        #include "legacy_C_header.h"
+        }
+      '''
+      expect(lines[0][0]).toEqual value: 'extern', scopes: ['source.cpp', 'meta.extern-block.cpp', 'storage.modifier.cpp']
+      expect(lines[0][2]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.c', 'punctuation.definition.string.begin.c']
+      expect(lines[0][3]).toEqual value: 'C', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.c']
+      expect(lines[0][4]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.c', 'punctuation.definition.string.end.c']
+      expect(lines[0][6]).toEqual value: '{', scopes: ['source.cpp', 'meta.extern-block.cpp', 'punctuation.section.block.begin.c']
+      expect(lines[1][0]).toEqual value: '#', scopes: ['source.cpp', 'meta.extern-block.cpp', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c', 'punctuation.definition.directive.c']
+      expect(lines[1][1]).toEqual value: 'include', scopes: ['source.cpp', 'meta.extern-block.cpp', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c']
+      expect(lines[1][3]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'meta.preprocessor.include.c', 'string.quoted.double.include.c', 'punctuation.definition.string.begin.c']
+      expect(lines[1][4]).toEqual value: 'legacy_C_header.h', scopes: ['source.cpp', 'meta.extern-block.cpp', 'meta.preprocessor.include.c', 'string.quoted.double.include.c']
+      expect(lines[1][5]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'meta.preprocessor.include.c', 'string.quoted.double.include.c', 'punctuation.definition.string.end.c']
+      expect(lines[2][0]).toEqual value: '}', scopes: ['source.cpp', 'meta.extern-block.cpp', 'punctuation.section.block.end.c']
+
+      lines = grammar.tokenizeLines '''
+        #ifdef __cplusplus
+        extern "C" {
+        #endif
+          // legacy C code here
+        #ifdef __cplusplus
+        }
+        #endif
+      '''
+      expect(lines[0][0]).toEqual value: '#', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+      expect(lines[0][1]).toEqual value: 'ifdef', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
+      expect(lines[0][2]).toEqual value: ' __cplusplus', scopes: ['source.cpp', 'meta.preprocessor.c']
+      expect(lines[1][0]).toEqual value: 'extern', scopes: ['source.cpp', 'meta.extern-block.cpp', 'storage.modifier.cpp']
+      expect(lines[1][2]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.c', 'punctuation.definition.string.begin.c']
+      expect(lines[1][3]).toEqual value: 'C', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.c']
+      expect(lines[1][4]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.c', 'punctuation.definition.string.end.c']
+      expect(lines[1][6]).toEqual value: '{', scopes: ['source.cpp', 'meta.extern-block.cpp', 'punctuation.section.block.begin.c']
+      expect(lines[2][0]).toEqual value: '#', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+      expect(lines[2][1]).toEqual value: 'endif', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
+      expect(lines[3][1]).toEqual value: '//', scopes: ['source.cpp', 'comment.line.double-slash.c++', 'punctuation.definition.comment.c++']
+      expect(lines[3][2]).toEqual value: ' legacy C code here', scopes: ['source.cpp', 'comment.line.double-slash.c++']
+      expect(lines[4][0]).toEqual value: '#', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+      expect(lines[4][1]).toEqual value: 'ifdef', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
+      expect(lines[5][0]).toEqual value: '}', scopes: ['source.cpp']
+      expect(lines[6][0]).toEqual value: '#', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
+      expect(lines[6][1]).toEqual value: 'endif', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
+
     describe "comments", ->
       it "tokenizes them", ->
         {tokens} = grammar.tokenizeLine '// comment'

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -62,6 +62,20 @@ describe "Language-C", ->
           expect(tokens[1]).toEqual value: 'a', scopes: ['source.c', scope]
           expect(tokens[2]).toEqual value: delim, scopes: ['source.c', scope, 'punctuation.definition.string.end.c']
 
+    describe "comments", ->
+      it "tokenizes them", ->
+        {tokens} = grammar.tokenizeLine '/**/'
+        expect(tokens[0]).toEqual value: '/*', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.begin.c']
+        expect(tokens[1]).toEqual value: '*/', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.end.c']
+
+        {tokens} = grammar.tokenizeLine '/* foo */'
+        expect(tokens[0]).toEqual value: '/*', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.begin.c']
+        expect(tokens[1]).toEqual value: ' foo ', scopes: ['source.c', 'comment.block.c']
+        expect(tokens[2]).toEqual value: '*/', scopes: ['source.c', 'comment.block.c', 'punctuation.definition.comment.end.c']
+
+        {tokens} = grammar.tokenizeLine '*/*'
+        expect(tokens[0]).toEqual value: '*/*', scopes: ['source.c', 'invalid.illegal.stray-comment-end.c']
+
     describe "preprocessor directives", ->
       it "tokenizes '#line'", ->
         {tokens} = grammar.tokenizeLine '#line 151 "copy.c"'
@@ -470,3 +484,18 @@ describe "Language-C", ->
       '''
       expect(lines[0][0]).toEqual value: 'class', scopes: ['source.cpp', 'meta.class-struct-block.cpp', 'storage.type.cpp']
       expect(lines[0][2]).toEqual value: 'Thing', scopes: ['source.cpp', 'meta.class-struct-block.cpp', 'entity.name.type.cpp']
+
+    describe "comments", ->
+      it "tokenizes them", ->
+        {tokens} = grammar.tokenizeLine '// comment'
+        expect(tokens[0]).toEqual value: '//', scopes: ['source.cpp', 'comment.line.double-slash.c++', 'punctuation.definition.comment.c++']
+        expect(tokens[1]).toEqual value: ' comment', scopes: ['source.cpp', 'comment.line.double-slash.c++']
+
+        lines = grammar.tokenizeLines '''
+          // separated\\
+          comment
+        '''
+        expect(lines[0][0]).toEqual value: '//', scopes: ['source.cpp', 'comment.line.double-slash.c++', 'punctuation.definition.comment.c++']
+        expect(lines[0][1]).toEqual value: ' separated', scopes: ['source.cpp', 'comment.line.double-slash.c++']
+        expect(lines[0][2]).toEqual value: '\\', scopes: ['source.cpp', 'comment.line.double-slash.c++', 'punctuation.separator.continuation.c++']
+        expect(lines[1][0]).toEqual value: 'comment', scopes: ['source.cpp', 'comment.line.double-slash.c++']

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -51,7 +51,7 @@ describe "Language-C", ->
       expect(tokens[0]).toEqual value: 'myType_t', scopes: ['source.c', 'support.type.posix-reserved.c']
 
     it "tokenizes 'line continuation' character", ->
-      {tokens} = grammar.tokenizeLine 'ma\\\nin(){);'
+      {tokens} = grammar.tokenizeLine 'ma' + '\\' + '\n' + 'in(){};'
       expect(tokens[0]).toEqual value: 'ma', scopes: ['source.c']
       expect(tokens[1]).toEqual value: '\\', scopes: ['source.c', 'constant.character.escape.line-continuation.c']
       expect(tokens[3]).toEqual value: 'in', scopes: ['source.c', 'meta.function.c', 'entity.name.function.c']


### PR DESCRIPTION
1. Added specs for preprocessor directives
2. `keyword.control.import...` -> `keyword.control.directive...`

   I think it's confusing that all preprocessor directives are tokenized as `import`
3. `#` is tokenized as part of a keyword

   Before (added in #79): `#` - `punctuation.definition.keyword`, `define` - `keyword.control.import`
   After: `#define` - `keyword.control.directive`, `#` - `punctuation.definition.directive`

4. Strings and numbers are tokenized in `#line 151 "copy.c"` 
5. Fixes #92
```c
// diagnostics
#error C++ compiler required.
#warning This is a warning.

// includes
#include <stdio.h>
#include<stdio.h>
#import "filename"
#import"filename"

// '#pragma'
#pragma mark – Initialization
#pragma once
#pragma OPTIMIZE ON

// '#line'
#line 151 "copy.c"

// conditionals
#if defined(CREDIT)
    credit();
#elif defined(DEBIT)
    debit();
#else
    printerror();
#endif
#if 0
  return 1;
#else
  return 0;
#endif
#if 1
  return 1;
#else
  return 0;
#endif
#if (DEBUG && !MYTEST)
        Console.WriteLine("DEBUG is defined");
#elif (!DEBUG && MYTEST)
        Console.WriteLine("MYTEST is defined");
#elif (DEBUG && MYTEST)
        Console.WriteLine("DEBUG and MYTEST are defined");
#else
        Console.WriteLine("DEBUG and MYTEST are not defined");
#endif
#ifdef __unix__ /* is defined by compilers targeting Unix systems */
  # include <unistd.h>
#elif defined _WIN32 /* is defined by compilers targeting Windows systems */
  # include <windows.h>
#endif

// '#define'
#define _FILE_NAME_H_
#define ABC XYZ(1)
#define PI_PLUS_ONE (3.14 + 1)
#define INCREMENT(x) x++
#define MULT(x, y) x * y
#define multiply( f1, f2 ) ( f1 * f2 )
#define MULT(x, y) (x) * (y)
#define SWAP(a, b)  do { a ^= b; b ^= a; a ^= b; } while ( 0 )
#define max(a,b) (a>b)? \
                  a:b
#define SWAP(a, b)  { \
  a ^= b;             \
  b ^= a;             \
  a ^= b;             \
}

// 'line continuation' character
#include<stdio.h>
ma\
in()
{
p\
r\
i\
n\
t\
f (
  "Hello\
  World"
  );
}

// #92
#ifdef __cplusplus
extern "C" {
#endif
```