### PR TITLE
Improve 'firstLineMatch'

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -17,7 +17,7 @@
   'tcc'
   'tpp'
 ]
-'firstLineMatch': '-\\*- C\\+\\+ -\\*-'
+'firstLineMatch': '-\\*-\\s*([Mm]ode: )?C\\+\\+;?\\s*-\\*-'
 'name': 'C++'
 'patterns': [
   {

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -3,7 +3,7 @@
   'c'
   'h'
 ]
-'firstLineMatch': '-[*]-( Mode:)? C -[*]-'
+'firstLineMatch': '-\\*-\\s*([Mm]ode: )?C;?\\s*-\\*-'
 'name': 'C'
 'patterns': [
   {


### PR DESCRIPTION
Improve the 'firstLineMatch' regular expression for both C and C++ to be more tolerant of whitespace (or lack thereof).

<img width="341" alt="screen shot 2015-11-26 at 12 28 05 am" src="https://cloud.githubusercontent.com/assets/415822/11415739/a14a88c8-93d4-11e5-9d76-e856e0cc7e63.png">
