### PR TITLE
Updated indentation regexes for new language-mode logic

### DIFF
--- a/settings/language-c.cson
+++ b/settings/language-c.cson
@@ -2,17 +2,19 @@
   'editor':
     'commentStart': '// '
     'increaseIndentPattern': '(?x)
-       ^ .* \\{ [^}"\']* $
-      |^ .* \\( [^\\)"\']* $
+       [\\{\\(]
       |^ \\s* (public|private|protected): \\s* $
       |^ \\s* @(public|private|protected) \\s* $
       |^ \\s* \\{ \\} $
       '
-    'decreaseIndentPattern': '(?x)
+    'decreaseThisIndentPattern': '(?x)
        ^ \\s* (\\s* /[*] .* [*]/ \\s*)* \\}
       |^ \\s* (\\s* /[*] .* [*]/ \\s*)* \\)
       |^ \\s* (public|private|protected): \\s* $
       |^ \\s* @(public|private|protected) \\s* $
+      '
+    'decreaseIndentPattern': '(?x)
+       [\\}\\)]
       '
 '.source.c, .source.cpp':
   'editor':


### PR DESCRIPTION
This is for the following atom/atom PR:
https://github.com/atom/atom/pull/10384

There is a cyclic dependency between these two (an artifact caused by
the separation of the two repos). Hence, both test suits (for this
package as well as for atom/atom, will fail until both are merged.