### PR TITLE
Add `noexcept` to the list of storage modifiers

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -251,7 +251,7 @@
         'include': '#parens'
       }
       {
-        'match': '\\b(const|override|final)\\b'
+        'match': '\\b(const|override|final|noexcept)\\b'
         'name': 'storage.modifier.c'
       }
       {


### PR DESCRIPTION
`noexcept` is a keyword in C++11, but is not listed in the grammar. As a result, this doesn't syntax-highlight properly:

```cpp
class foo
{
public:
    void bar() const noexcept;
};
```

cc @50Wliu 