### PR TITLE
Move C++11 keywords to c++.cson

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -27,7 +27,7 @@
     'include': 'source.c'
   }
   {
-    'match': '\\b(friend|explicit|virtual)\\b'
+    'match': '\\b(friend|explicit|virtual|override|final|noexcept)\\b'
     'name': 'storage.modifier.cpp'
   }
   {
@@ -64,15 +64,15 @@
     'name': 'keyword.operator.cast.cpp'
   }
   {
-    'match': '\\b(and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq)\\b'
+    'match': '\\b(and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\b'
     'name': 'keyword.operator.cpp'
   }
   {
-    'match': '\\b(class|decltype|wchar_t)\\b'
+    'match': '\\b(class|decltype|wchar_t|char16_t|char32_t)\\b'
     'name': 'storage.type.cpp'
   }
   {
-    'match': '\\b(constexpr|export|mutable|typename)\\b'
+    'match': '\\b(constexpr|export|mutable|typename|thread_local)\\b'
     'name': 'storage.modifier.cpp'
   }
   {

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -251,7 +251,7 @@
         'include': '#parens'
       }
       {
-        'match': '\\b(const|override|final|noexcept)\\b'
+        'match': '\\b(const)\\b'
         'name': 'storage.modifier.c'
       }
       {


### PR DESCRIPTION
Moves all of the C++11 keywords to `c++.cson` and adds a few more, as well.

The full list can be found here: http://en.cppreference.com/w/cpp/keyword

cc @50Wliu 