### PR TITLE
Adding types comply with good programming practice

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -215,7 +215,7 @@
   }
   {
     'comment': 'Reserved for a good pratice types'
-    'match': '\\b([A-Za-z0-9_]+_[esuap])\\b'
+    'match': '\\b([A-Za-z0-9_]+_[aefpsu])\\b'
     'name': 'support.type.good-practice-reserved.c'
   }
   {

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -214,6 +214,11 @@
     'name': 'support.type.posix-reserved.c'
   }
   {
+    'comment': 'Reserved for a good pratice types'
+    'match': '\\b([A-Za-z0-9_]+_[esuap])\\b'
+    'name': 'support.type.good-practice-reserved.c'
+  }
+  {
     'include': '#block'
   }
   {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.51.3",
-  "name": "language-c-custom",
-  "description": "Atom language support for C/C++ custom",
+  "name": "language-c",
+  "description": "Atom language support for C/C++",
   "homepage": "https://atom.github.io/language-c",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.51.3",
-  "name": "language-c",
-  "description": "Atom language support for C/C++",
+  "name": "language-c-custom",
+  "description": "Atom language support for C/C++ custom",
   "homepage": "https://atom.github.io/language-c",
   "repository": {
     "type": "git",

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -50,6 +50,9 @@ describe "Language-C", ->
       {tokens} = grammar.tokenizeLine 'myType_t var;'
       expect(tokens[0]).toEqual value: 'myType_t', scopes: ['source.c', 'support.type.posix-reserved.c']
 
+      {tokens} = grammar.tokenizeLine 'myTypeGoodPractice_t var;'
+      expect(tokens[0]).toEqual value: 'myTypeGoodPractice_t', scopes: ['source.c', 'support.type.good-practice-reserved.c']
+
     it "tokenizes 'line continuation' character", ->
       {tokens} = grammar.tokenizeLine 'ma' + '\\' + '\n' + 'in(){};'
       expect(tokens[0]).toEqual value: 'ma', scopes: ['source.c']


### PR DESCRIPTION
It is recommended not to use the suffix _t 'because it is reserved by
the POSIX standard for defining type aliases (potential conflict)

xxx_e : typedef enum
xxx_u : typedef union
xxx_s : typedef struct
xxx_a : array
xxx_f  : function
xxx_p : primitive type