### PR TITLE
Partially solve issue 136

### DIFF
--- a/settings/language-c.cson
+++ b/settings/language-c.cson
@@ -3,10 +3,16 @@
     'commentStart': '// '
     'increaseIndentPattern': '(?x)
        ^ .* \\{ [^}"\']* $
+      |\\([^)]*$
+      |\\[[^\\]]*$
       |^ .* \\( [^\\)"\']* $
       |^ \\s* (public|private|protected): \\s* $
       |^ \\s* @(public|private|protected) \\s* $
       |^ \\s* \\{ \\} $
+      '
+    'decreaseNextIndentPattern': '(?x)
+      ^[^(]*\\);
+      |^[^\\[]*\\];
       '
     'decreaseIndentPattern': '(?x)
        ^ \\s* (\\s* /[*] .* [*]/ \\s*)* \\}


### PR DESCRIPTION
Now indent works mostly correct, although function argument is still not aligned.
```c++
int main() {
  indent_function(abc,
    abc);
  int indent_list = [
    1, 2,
    3];
  int always_reset_indent;
}
```