### PR TITLE
Improve handling of Emacs modeline detection

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -17,7 +17,7 @@
   'tcc'
   'tpp'
 ]
-'firstLineMatch': '-\\*-\\s*([Mm]ode:\\s*)?C\\+\\+\\s*(;.*?)?\\s*-\\*-'
+'firstLineMatch': '-\\*-\\s*([Mm]ode:\\s*)?C\\+\\+(\\s*;.*?)?\\s*-\\*-'
 'name': 'C++'
 'patterns': [
   {

--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -17,7 +17,7 @@
   'tcc'
   'tpp'
 ]
-'firstLineMatch': '-\\*-\\s*([Mm]ode: )?C\\+\\+;?\\s*-\\*-'
+'firstLineMatch': '-\\*-\\s*([Mm]ode:\\s*)?C\\+\\+\\s*(;.*?)?\\s*-\\*-'
 'name': 'C++'
 'patterns': [
   {

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -3,7 +3,7 @@
   'c'
   'h'
 ]
-'firstLineMatch': '-\\*-\\s*([Mm]ode:\\s*)?C\\s*(;.*?)?\\s*-\\*-'
+'firstLineMatch': '-\\*-\\s*([Mm]ode:\\s*)?C(\\s*;.*?)?\\s*-\\*-'
 'name': 'C'
 'patterns': [
   {

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -3,7 +3,7 @@
   'c'
   'h'
 ]
-'firstLineMatch': '-\\*-\\s*([Mm]ode: )?C;?\\s*-\\*-'
+'firstLineMatch': '-\\*-\\s*([Mm]ode:\\s*)?C\\s*(;.*?)?\\s*-\\*-'
 'name': 'C'
 'patterns': [
   {


### PR DESCRIPTION
The current `firstLineMatch` pattern doesn't cater for additional arguments in Emacs modelines. For instance, [this file](https://github.com/LibreOffice/core/blob/master/offapi/com/sun/star/accessibility/Accessible.idl) would fail to be detected as C++:

```c++
/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
```

Furthermore, whitespace between arguments is optional, and may be of any length. For instance, these are both valid modelines in Emacs:

```
-*- Mode: C++;  indent-tabs-mode: nil; c-basic-offset: 4 -*-
-*- Mode:    C++	 	 	 	  		 ; tab-width:   4   ;     c-basic-offset:  4     -*-
```