### PR TITLE
Fix pattern-matching of Emacs modelines

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -17,7 +17,7 @@
   'tcc'
   'tpp'
 ]
-'firstLineMatch': '-\\*-[^*]*([Mm]ode:\\s*)?C\\+\\+(\\s*;.*?)?\\s*-\\*-'
+'firstLineMatch': '(?i)-\\*-[^*]*(Mode:\\s*)?C\\+\\+(\\s*;.*?)?\\s*-\\*-'
 'name': 'C++'
 'patterns': [
   {

--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -17,7 +17,7 @@
   'tcc'
   'tpp'
 ]
-'firstLineMatch': '-\\*-\\s*([Mm]ode:\\s*)?C\\+\\+(\\s*;.*?)?\\s*-\\*-'
+'firstLineMatch': '-\\*-[^*]*([Mm]ode:\\s*)?C\\+\\+(\\s*;.*?)?\\s*-\\*-'
 'name': 'C++'
 'patterns': [
   {

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -3,7 +3,7 @@
   'c'
   'h'
 ]
-'firstLineMatch': '-\\*-[^*]*([Mm]ode:\\s*)?C(\\s*;.*?)?\\s*-\\*-'
+'firstLineMatch': '(?i)-\\*-[^*]*(Mode:\\s*)?C(\\s*;.*?)?\\s*-\\*-'
 'name': 'C'
 'patterns': [
   {

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -3,7 +3,7 @@
   'c'
   'h'
 ]
-'firstLineMatch': '-\\*-\\s*([Mm]ode:\\s*)?C(\\s*;.*?)?\\s*-\\*-'
+'firstLineMatch': '-\\*-[^*]*([Mm]ode:\\s*)?C(\\s*;.*?)?\\s*-\\*-'
 'name': 'C'
 'patterns': [
   {


### PR DESCRIPTION
Sorry about the separate pull request: I've never looked at modelines until tonight, so I'm learning as I go. 

Just learned Emacs doesn't require variables to be defined in any particular order, so the following modeline is valid:

```c++
/* -*- tab-width: 4; Mode: C++; c-basic-offset: 4 -*- */
```

For some reason, it doesn't mind if you leave a semicolon off the preceding variable, so this is valid too:

```c++
/* -*- tab-width: 4 Mode: C++; c-basic-offset: 4 -*- */
```

It also reads the mode variable case-insensitively, so it doesn't care how you capitalise it:

```c++
/* -*- Mode: C++ -*- */
/* -*- mode: c++ -*- */
/* -*- mOdE: C++; age: 14; -*- */
```

Sorry. That's really all.