### PR TITLE
Tokenize binary literal as 'constant.numeric.c'

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -424,7 +424,7 @@
   'numbers':
     'patterns': [
       {
-        'match': '\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b'
+        'match': '\\b((0(x|X)[0-9a-fA-F]*)|(0(b|B)[01]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b'
         'name': 'constant.numeric.c'
       }
     ]

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -496,6 +496,10 @@ describe "Language-C", ->
           };
         '''
 
+      it "tokenizes binary literal", ->
+        {tokens} = grammar.tokenizeLine '0b101010'
+        expect(tokens[0]).toEqual value: '0b101010', scopes: ['source.c', 'constant.numeric.c']
+
   describe "C++", ->
     beforeEach ->
       grammar = atom.grammars.grammarForScopeName('source.cpp')


### PR DESCRIPTION
From #127, I add binary literal support for both C and C++.