### PR TITLE
Update c.son - Added '$' as a valid macro name.

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -59,7 +59,7 @@
   {
     'begin': '''(?x)
       ^\\s* ((\\#)\\s*define) \\s+     # define
-      ((?<id>[a-zA-Z_][a-zA-Z0-9_]*))  # macro name
+      ((?<id>[a-zA-Z_$][a-zA-Z0-9_$]*))  # macro name
       (?:
         (\\()
           (

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -59,7 +59,7 @@
   {
     'begin': '''(?x)
       ^\\s* ((\\#)\\s*define) \\s+     # define
-      ((?<id>[a-zA-Z_$][a-zA-Z0-9_$]*))  # macro name
+      ((?<id>[a-zA-Z_$][\\w$]*))  # macro name
       (?:
         (\\()
           (


### PR DESCRIPTION
Some pre-processor admit the dollar sign character as a macro name.

It's the case for GCC and Clang even if it's not used very often, and i'm using it sometime for debug :D