### PR TITLE
Removed .h from C. C is a subset of the superset C++ and does not req…

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -1,7 +1,6 @@
 'scopeName': 'source.c'
 'fileTypes': [
   'c'
-  'h'
 ]
 'firstLineMatch': '(?i)-\\*-[^*]*(Mode:\\s*)?C(\\s*;.*?)?\\s*-\\*-'
 'name': 'C'


### PR DESCRIPTION
Removed .h from C. C is a subset of the superset C++ and does not require .h within it. Atom looks at C first and formats and syntax highlights .h class files like C does and this creates problems. C highlighting will be the same, CPP class highlighting fixed.