### PR TITLE
Support for C++11 raw/unicode strings

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -25,6 +25,9 @@
     'include': '#special_block'
   }
   {
+    'include': '#strings'
+  }
+  {
     'include': 'source.c'
   }
   {
@@ -327,5 +330,56 @@
             'include': '$base'
           }
         ]
+      }
+    ]
+  'strings':
+    'patterns': [
+      {
+        'begin': '(u|u8|U|L)?"'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.cpp'
+          '1':
+            'name': 'meta.encoding.cpp'
+        'end': '"'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.cpp'
+        'name': 'string.quoted.double.cpp'
+        'patterns': [
+          {
+            'match': '\\\\u\\h{4}|\\\\U\\h{8}'
+            'name': 'constant.character.escape.cpp'
+          }
+          {
+            'match': '\\\\[\'"?\\\\abfnrtv]'
+            'name': 'constant.character.escape.cpp'
+          }
+          {
+            'match': '\\\\[0-7]{1,3}'
+            'name': 'constant.character.escape.cpp'
+          }
+          {
+            'match': '\\\\x\\h+'
+            'name': 'constant.character.escape.cpp'
+          }
+        ]
+      }
+      {
+        'begin': '(u|u8|U|L)?R"(?:([^ ()\\\\\\t]{0,16})|([^ ()\\\\\\t]*))\\('
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.cpp'
+          '1':
+            'name': 'meta.encoding.cpp'
+          '3':
+            'name': 'invalid.illegal.delimiter-too-long.cpp'
+        'end': '\\)\\2(\\3)"'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.cpp'
+          '1':
+            'name': 'invalid.illegal.delimiter-too-long.cpp'
+        'name': 'string.quoted.double.raw.cpp'
       }
     ]

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -555,9 +555,9 @@ describe "Language-C", ->
         }
       '''
       expect(lines[0][0]).toEqual value: 'extern', scopes: ['source.cpp', 'meta.extern-block.cpp', 'storage.modifier.cpp']
-      expect(lines[0][2]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.c', 'punctuation.definition.string.begin.c']
-      expect(lines[0][3]).toEqual value: 'C', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.c']
-      expect(lines[0][4]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.c', 'punctuation.definition.string.end.c']
+      expect(lines[0][2]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.begin.cpp']
+      expect(lines[0][3]).toEqual value: 'C', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.cpp']
+      expect(lines[0][4]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.end.cpp']
       expect(lines[0][6]).toEqual value: '{', scopes: ['source.cpp', 'meta.extern-block.cpp', 'punctuation.section.block.begin.c']
       expect(lines[1][0]).toEqual value: '#', scopes: ['source.cpp', 'meta.extern-block.cpp', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c', 'punctuation.definition.directive.c']
       expect(lines[1][1]).toEqual value: 'include', scopes: ['source.cpp', 'meta.extern-block.cpp', 'meta.preprocessor.include.c', 'keyword.control.directive.include.c']
@@ -579,9 +579,9 @@ describe "Language-C", ->
       expect(lines[0][1]).toEqual value: 'ifdef', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
       expect(lines[0][2]).toEqual value: ' __cplusplus', scopes: ['source.cpp', 'meta.preprocessor.c']
       expect(lines[1][0]).toEqual value: 'extern', scopes: ['source.cpp', 'meta.extern-block.cpp', 'storage.modifier.cpp']
-      expect(lines[1][2]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.c', 'punctuation.definition.string.begin.c']
-      expect(lines[1][3]).toEqual value: 'C', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.c']
-      expect(lines[1][4]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.c', 'punctuation.definition.string.end.c']
+      expect(lines[1][2]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.begin.cpp']
+      expect(lines[1][3]).toEqual value: 'C', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.cpp']
+      expect(lines[1][4]).toEqual value: '"', scopes: ['source.cpp', 'meta.extern-block.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.end.cpp']
       expect(lines[1][6]).toEqual value: '{', scopes: ['source.cpp', 'meta.extern-block.cpp', 'punctuation.section.block.begin.c']
       expect(lines[2][0]).toEqual value: '#', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
       expect(lines[2][1]).toEqual value: 'endif', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
@@ -592,6 +592,47 @@ describe "Language-C", ->
       expect(lines[5][0]).toEqual value: '}', scopes: ['source.cpp']
       expect(lines[6][0]).toEqual value: '#', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
       expect(lines[6][1]).toEqual value: 'endif', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
+
+    it "tokenizes UTF string escapes", ->
+      lines = grammar.tokenizeLines '''
+        string str = U"\\U01234567\\u0123\\"\\0123\\x123";
+      '''
+      expect(lines[0][0]).toEqual value: 'string str = ', scopes: ['source.cpp']
+      expect(lines[0][1]).toEqual value: 'U', scopes: ['source.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.begin.cpp', 'meta.encoding.cpp']
+      expect(lines[0][2]).toEqual value: '"', scopes: ['source.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.begin.cpp']
+      expect(lines[0][3]).toEqual value: '\\U01234567', scopes: ['source.cpp', 'string.quoted.double.cpp', 'constant.character.escape.cpp']
+      expect(lines[0][4]).toEqual value: '\\u0123', scopes: ['source.cpp', 'string.quoted.double.cpp', 'constant.character.escape.cpp']
+      expect(lines[0][5]).toEqual value: '\\"', scopes: ['source.cpp', 'string.quoted.double.cpp', 'constant.character.escape.cpp']
+      expect(lines[0][6]).toEqual value: '\\012', scopes: ['source.cpp', 'string.quoted.double.cpp', 'constant.character.escape.cpp']
+      expect(lines[0][7]).toEqual value: '3', scopes: ['source.cpp', 'string.quoted.double.cpp']
+      expect(lines[0][8]).toEqual value: '\\x123', scopes: ['source.cpp', 'string.quoted.double.cpp', 'constant.character.escape.cpp']
+      expect(lines[0][9]).toEqual value: '"', scopes: ['source.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.end.cpp']
+      expect(lines[0][10]).toEqual value: ';', scopes: ['source.cpp']
+
+    it "tokenizes raw string literals", ->
+      lines = grammar.tokenizeLines '''
+        string str = R"test(
+          this is \"a\" test 'string'
+        )test";
+      '''
+      expect(lines[0][0]).toEqual value: 'string str = ', scopes: ['source.cpp']
+      expect(lines[0][1]).toEqual value: 'R"test(', scopes: ['source.cpp', 'string.quoted.double.raw.cpp', 'punctuation.definition.string.begin.cpp']
+      expect(lines[1][0]).toEqual value: '  this is "a" test \'string\'', scopes: ['source.cpp', 'string.quoted.double.raw.cpp']
+      expect(lines[2][0]).toEqual value: ')test"', scopes: ['source.cpp', 'string.quoted.double.raw.cpp', 'punctuation.definition.string.end.cpp']
+      expect(lines[2][1]).toEqual value: ';', scopes: ['source.cpp']
+
+    it "errors on long raw string delimiters", ->
+      lines = grammar.tokenizeLines '''
+        string str = R"01234567890123456()01234567890123456";
+      '''
+      expect(lines[0][0]).toEqual value: 'string str = ', scopes: ['source.cpp']
+      expect(lines[0][1]).toEqual value: 'R"', scopes: ['source.cpp', 'string.quoted.double.raw.cpp', 'punctuation.definition.string.begin.cpp']
+      expect(lines[0][2]).toEqual value: '01234567890123456', scopes: ['source.cpp', 'string.quoted.double.raw.cpp', 'punctuation.definition.string.begin.cpp', 'invalid.illegal.delimiter-too-long.cpp']
+      expect(lines[0][3]).toEqual value: '(', scopes: ['source.cpp', 'string.quoted.double.raw.cpp', 'punctuation.definition.string.begin.cpp']
+      expect(lines[0][4]).toEqual value: ')', scopes: ['source.cpp', 'string.quoted.double.raw.cpp', 'punctuation.definition.string.end.cpp']
+      expect(lines[0][5]).toEqual value: '01234567890123456', scopes: ['source.cpp', 'string.quoted.double.raw.cpp', 'punctuation.definition.string.end.cpp', 'invalid.illegal.delimiter-too-long.cpp']
+      expect(lines[0][6]).toEqual value: '"', scopes: ['source.cpp', 'string.quoted.double.raw.cpp', 'punctuation.definition.string.end.cpp']
+      expect(lines[0][7]).toEqual value: ';', scopes: ['source.cpp']
 
     describe "comments", ->
       it "tokenizes them", ->


### PR DESCRIPTION
Fixes #117. This is a direct port of @infininight's corresponding code in
- https://github.com/textmate/c.tmbundle/commit/022ffeb698bcb30ae89c459a4f11487ea4f5ecb8
- https://github.com/textmate/c.tmbundle/commit/fa4b7e211463973328b5334d55d0b10dafa27122

Wrote some unit tests and opened a real file with C++11 raw strings.