### PR TITLE
Fix meta.function.c end pattern

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -241,7 +241,7 @@
         'name': 'entity.name.function.c'
       '4':
         'name': 'punctuation.definition.parameters.c'
-    'end': '(?<=\\})|(?=#)|(;)'
+    'end': '(?<=\\))|(?=#)|(;)'
     'name': 'meta.function.c'
     'patterns': [
       {


### PR DESCRIPTION
Fix issue #160

Lines of the form `#define foo bar()` never exit from matching meta.function.c until a `;` is seen. Changing the look-behind from a } to ) fixes syntax highlighting for this case.