### PR TITLE
Fix for improper highlighting within the ternary operator

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -828,6 +828,15 @@
           {
             'include': '$self'
           }
+          {
+            'include': '#access'
+          }
+          {
+            'include': '#libc'
+          }
+          {
+            'include': '#c_function_call'
+          }
         ]
       }
     ]

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -826,10 +826,10 @@
             'name': 'keyword.operator.ternary.c'
         'patterns': [
           {
-            'include': '$self'
+            'include': '#access'
           }
           {
-            'include': '#access'
+            'include': '$self'
           }
           {
             'include': '#libc'

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -829,13 +829,13 @@
             'include': '#access'
           }
           {
-            'include': '$self'
-          }
-          {
             'include': '#libc'
           }
           {
             'include': '#c_function_call'
+          }
+          {
+            'include': '$self'
           }
         ]
       }

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -613,6 +613,28 @@ describe "Language-C", ->
         expect(tokens[3]).toEqual value: ':', scopes: ['source.c', 'keyword.operator.ternary.c']
         expect(tokens[4]).toEqual value: ' c', scopes: ['source.c']
 
+      it "tokenizes ternary operators with member access", ->
+        {tokens} = grammar.tokenizeLine('a ? b.c : d')
+        expect(tokens[0]).toEqual value: 'a ', scopes: ['source.c']
+        expect(tokens[1]).toEqual value: '?', scopes: ['source.c', 'keyword.operator.ternary.c']
+        expect(tokens[2]).toEqual value: ' b', scopes: ['source.c']
+        expect(tokens[3]).toEqual value: '.', scopes: ['source.c', 'punctuation.separator.dot-access.c']
+        expect(tokens[4]).toEqual value: 'c', scopes: ['source.c', 'variable.other.member.c']
+        expect(tokens[5]).toEqual value: ' ', scopes: ['source.c']
+        expect(tokens[6]).toEqual value: ':', scopes: ['source.c', 'keyword.operator.ternary.c']
+        expect(tokens[7]).toEqual value: ' d', scopes: ['source.c']
+
+      it "tokenizes ternary operators with function invocation", ->
+        {tokens} = grammar.tokenizeLine('a ? f(b) : c')
+        expect(tokens[0]).toEqual value: 'a ', scopes: ['source.c']
+        expect(tokens[1]).toEqual value: '?', scopes: ['source.c', 'keyword.operator.ternary.c']
+        expect(tokens[2]).toEqual value: ' ', scopes: ['source.c', 'meta.function-call.c', 'punctuation.whitespace.function-call.leading.c']
+        expect(tokens[3]).toEqual value: 'f', scopes: ['source.c', 'meta.function-call.c', 'support.function.any-method.c']
+        expect(tokens[4]).toEqual value: '(', scopes: ['source.c', 'meta.function-call.c', 'punctuation.definition.parameters.c']
+        expect(tokens[5]).toEqual value: 'b) ', scopes: ['source.c']
+        expect(tokens[6]).toEqual value: ':', scopes: ['source.c', 'keyword.operator.ternary.c']
+        expect(tokens[7]).toEqual value: ' c', scopes: ['source.c']
+
       describe "bitwise", ->
         it "tokenizes bitwise 'not'", ->
           {tokens} = grammar.tokenizeLine('~a')

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -624,6 +624,17 @@ describe "Language-C", ->
         expect(tokens[6]).toEqual value: ':', scopes: ['source.c', 'keyword.operator.ternary.c']
         expect(tokens[7]).toEqual value: ' d', scopes: ['source.c']
 
+      it "tokenizes ternary operators with pointer dereferencing", ->
+        {tokens} = grammar.tokenizeLine('a ? b->c : d')
+        expect(tokens[0]).toEqual value: 'a ', scopes: ['source.c']
+        expect(tokens[1]).toEqual value: '?', scopes: ['source.c', 'keyword.operator.ternary.c']
+        expect(tokens[2]).toEqual value: ' b', scopes: ['source.c']
+        expect(tokens[3]).toEqual value: '->', scopes: ['source.c', 'punctuation.separator.pointer-access.c']
+        expect(tokens[4]).toEqual value: 'c', scopes: ['source.c', 'variable.other.member.c']
+        expect(tokens[5]).toEqual value: ' ', scopes: ['source.c']
+        expect(tokens[6]).toEqual value: ':', scopes: ['source.c', 'keyword.operator.ternary.c']
+        expect(tokens[7]).toEqual value: ' d', scopes: ['source.c']
+
       it "tokenizes ternary operators with function invocation", ->
         {tokens} = grammar.tokenizeLine('a ? f(b) : c')
         expect(tokens[0]).toEqual value: 'a ', scopes: ['source.c']


### PR DESCRIPTION
Now supports function and member access tokenizing. add corresponding specs

fix for #178 

Before:
![ternbefore](https://cloud.githubusercontent.com/assets/4008169/20803319/c0c9e65a-b7bc-11e6-834f-6ddcc9acf271.gif)

After:
![ternafter](https://cloud.githubusercontent.com/assets/4008169/20803332/cbda5ebc-b7bc-11e6-93ca-a484cbbdc045.gif)

