### PR TITLE
Tokenize access operators when there are no member variables followed

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -286,7 +286,7 @@
         'name': 'punctuation.separator.pointer-access.c'
       '4':
         'name': 'variable.other.member.c'
-    'match': '((\\.)|(->))([a-zA-Z_][a-zA-Z_0-9]*)\\b(?!\\s*\\()'
+    'match': '((\\.)|(->))(([a-zA-Z_][a-zA-Z_0-9]*)\\b(?!\\s*\\())?'
   'block':
     'patterns': [
       {

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -512,6 +512,14 @@ describe "Language-C", ->
     describe "access", ->
       it "tokenizes the dot access operator", ->
         lines = grammar.tokenizeLines '''
+          {
+            a.
+          }
+        '''
+        expect(lines[1][0]).toEqual value: '  a', scopes: ['source.c', 'meta.block.c']
+        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
+
+        lines = grammar.tokenizeLines '''
           void f() {
             a.b;
           }

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -516,7 +516,6 @@ describe "Language-C", ->
             a.b;
           }
         '''
-
         expect(lines[1][0]).toEqual value: '  a', scopes: ['source.c', 'meta.function.c', 'meta.block.c']
         expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
         expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -520,13 +520,13 @@ describe "Language-C", ->
         expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
 
         lines = grammar.tokenizeLines '''
-          void f() {
+          {
             a.b;
           }
         '''
-        expect(lines[1][0]).toEqual value: '  a', scopes: ['source.c', 'meta.function.c', 'meta.block.c']
-        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
-        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+        expect(lines[1][0]).toEqual value: '  a', scopes: ['source.c', 'meta.block.c']
+        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
+        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.block.c', 'variable.other.member.c']
 
         lines = grammar.tokenizeLines '''
           {
@@ -538,37 +538,37 @@ describe "Language-C", ->
         expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.block.c', 'meta.function-call.c', 'support.function.any-method.c']
 
         lines = grammar.tokenizeLines '''
-          void f() {
+          {
             a. b;
           }
         '''
-        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
-        expect(lines[1][3]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
+        expect(lines[1][3]).toEqual value: 'b', scopes: ['source.c', 'meta.block.c', 'variable.other.member.c']
 
         lines = grammar.tokenizeLines '''
-          void f() {
+          {
             a .b;
           }
         '''
-        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
-        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
+        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.block.c', 'variable.other.member.c']
 
         lines = grammar.tokenizeLines '''
-          void f() {
+          {
             a . b;
           }
         '''
-        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
-        expect(lines[1][3]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
+        expect(lines[1][3]).toEqual value: 'b', scopes: ['source.c', 'meta.block.c', 'variable.other.member.c']
 
       it "tokenizes the pointer access operator", ->
         lines = grammar.tokenizeLines '''
-          void f() {
+          {
             a->b;
           }
         '''
-        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
-        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
+        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.block.c', 'variable.other.member.c']
 
         lines = grammar.tokenizeLines '''
           {
@@ -579,28 +579,28 @@ describe "Language-C", ->
         expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
 
         lines = grammar.tokenizeLines '''
-          void f() {
+          {
             a-> b;
           }
         '''
-        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
-        expect(lines[1][3]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
+        expect(lines[1][3]).toEqual value: 'b', scopes: ['source.c', 'meta.block.c', 'variable.other.member.c']
 
         lines = grammar.tokenizeLines '''
-          void f() {
+          {
             a ->b;
           }
         '''
-        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
-        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
+        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.block.c', 'variable.other.member.c']
 
         lines = grammar.tokenizeLines '''
-          void f() {
+          {
             a -> b;
           }
         '''
-        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
-        expect(lines[1][3]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
+        expect(lines[1][3]).toEqual value: 'b', scopes: ['source.c', 'meta.block.c', 'variable.other.member.c']
 
         lines = grammar.tokenizeLines '''
           {

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -528,7 +528,7 @@ describe "Language-C", ->
         '''
         expect(lines[1][0]).toEqual value: '  a', scopes: ['source.c', 'meta.block.c']
         expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
-        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.block.c', 'variable.other.member.c']
+        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.block.c', 'meta.function-call.c', 'support.function.any-method.c']
 
         lines = grammar.tokenizeLines '''
           void f() {
@@ -562,7 +562,7 @@ describe "Language-C", ->
         '''
         expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
         expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
-        
+
         lines = grammar.tokenizeLines '''
           {
             a->b()

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -518,10 +518,25 @@ describe "Language-C", ->
             return 0;
           }
         '''
-
         expect(lines[2][0]).toEqual value: '  a', scopes: ['source.c', 'meta.function.c', 'meta.block.c']
         expect(lines[2][1]).toEqual value: '.', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
         expect(lines[2][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+
+        lines = grammar.tokenizeLines '''
+          {
+            a.
+          }
+        '''
+        expect(lines[1][0]).toEqual value: '  a', scopes: ['source.c', 'meta.block.c']
+        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
+
+        lines = grammar.tokenizeLines '''
+          {
+            a.b()
+          }
+        '''
+        expect(lines[1][0]).toEqual value: '  a', scopes: ['source.c', 'meta.block.c']
+        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
 
       it "should tokenizes pointer access", ->
         lines = grammar.tokenizeLines '''
@@ -531,10 +546,25 @@ describe "Language-C", ->
             return 0;
           }
         '''
-
         expect(lines[2][0]).toEqual value: '  a', scopes: ['source.c', 'meta.function.c', 'meta.block.c']
         expect(lines[2][1]).toEqual value: '->', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
         expect(lines[2][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+
+        lines = grammar.tokenizeLines '''
+          {
+            a->
+          }
+        '''
+        expect(lines[1][0]).toEqual value: '  a', scopes: ['source.c', 'meta.block.c']
+        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
+
+        lines = grammar.tokenizeLines '''
+          {
+            a->b()
+          }
+        '''
+        expect(lines[1][0]).toEqual value: '  a', scopes: ['source.c', 'meta.block.c']
+        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
 
     describe "operators", ->
       it "tokenizes the sizeof operator", ->

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -562,6 +562,14 @@ describe "Language-C", ->
         '''
         expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
         expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+        
+        lines = grammar.tokenizeLines '''
+          {
+            a->b()
+          }
+        '''
+        expect(lines[1][0]).toEqual value: '  a', scopes: ['source.c', 'meta.block.c']
+        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
 
         lines = grammar.tokenizeLines '''
           void f() {


### PR DESCRIPTION
```c
a.
a->
```