### PR TITLE
Remove redundant code

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -318,9 +318,6 @@
         'include': '#preprocessor-rule-other-block'
       }
       {
-        'include': '#sizeof'
-      }
-      {
         'include': '#access'
       }
       {


### PR DESCRIPTION
Since #163 `sizeof` operator is in `#operators` repo