### PR TITLE
Fix for improper highlighting within the pointer access operator

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -286,7 +286,7 @@
         'name': 'punctuation.separator.pointer-access.c'
       '4':
         'name': 'variable.other.member.c'
-    'match': '((\\.)|(->)\\s*)([a-zA-Z_][a-zA-Z_0-9]*)\\b(?!\\s*\\()'
+    'match': '((\\.)|(->))\\s*([a-zA-Z_][a-zA-Z_0-9]*)\\b(?!\\s*\\()'
   'block':
     'patterns': [
       {

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -286,7 +286,7 @@
         'name': 'punctuation.separator.pointer-access.c'
       '4':
         'name': 'variable.other.member.c'
-    'match': '((\\.)|(->))([a-zA-Z_][a-zA-Z_0-9]*)\\b(?!\\s*\\()'
+    'match': '((\\.)|(->)\\s*)([a-zA-Z_][a-zA-Z_0-9]*)\\b(?!\\s*\\()'
   'block':
     'patterns': [
       {

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -510,31 +510,71 @@ describe "Language-C", ->
         expect(tokens[0]).toEqual value: '0b101010', scopes: ['source.c', 'constant.numeric.c']
 
     describe "access", ->
-      it "should tokenizes dot access", ->
+      it "tokenizes the dot access operator", ->
         lines = grammar.tokenizeLines '''
-          int main() {
-            A a;
-            a.b = NULL;
-            return 0;
+          void f() {
+            a.b;
           }
         '''
+        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
+        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
 
-        expect(lines[2][0]).toEqual value: '  a', scopes: ['source.c', 'meta.function.c', 'meta.block.c']
-        expect(lines[2][1]).toEqual value: '.', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
-        expect(lines[2][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
-
-      it "should tokenizes pointer access", ->
         lines = grammar.tokenizeLines '''
-          int main() {
-            A *a;
-            a->b = NULL;
-            return 0;
+          void f() {
+            a. b;
           }
         '''
+        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
+        expect(lines[1][3]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
 
-        expect(lines[2][0]).toEqual value: '  a', scopes: ['source.c', 'meta.function.c', 'meta.block.c']
-        expect(lines[2][1]).toEqual value: '->', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
-        expect(lines[2][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+        lines = grammar.tokenizeLines '''
+          void f() {
+            a .b;
+          }
+        '''
+        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
+        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+
+        lines = grammar.tokenizeLines '''
+          void f() {
+            a . b;
+          }
+        '''
+        expect(lines[1][1]).toEqual value: '.', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.dot-access.c']
+        expect(lines[1][3]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+
+      it "tokenizes the pointer access operator", ->
+        lines = grammar.tokenizeLines '''
+          void f() {
+            a->b;
+          }
+        '''
+        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
+        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+
+        lines = grammar.tokenizeLines '''
+          void f() {
+            a-> b;
+          }
+        '''
+        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
+        expect(lines[1][3]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+
+        lines = grammar.tokenizeLines '''
+          void f() {
+            a ->b;
+          }
+        '''
+        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
+        expect(lines[1][2]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
+
+        lines = grammar.tokenizeLines '''
+          void f() {
+            a -> b;
+          }
+        '''
+        expect(lines[1][1]).toEqual value: '->', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'punctuation.separator.pointer-access.c']
+        expect(lines[1][3]).toEqual value: 'b', scopes: ['source.c', 'meta.function.c', 'meta.block.c', 'variable.other.member.c']
 
     describe "operators", ->
       it "tokenizes the sizeof operator", ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
This is a fix for issue #194 - any whitespace after a pointer access operator (->) would make tokenizing the operator fail, which in turn would impact syntax highlighting and any ligatures for that operator.

This change updates the regular expression used to identify valid uses of the pointer access operator to  include operators directly followed by whitespace.

### Benefits

<!-- What benefits will be realized by the code change? -->
Whitespace can now be added after a pointer access operator without affecting syntax highlighting or ligatures.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None. The change is minor.
