### PR TITLE
dont mark % at the end of the string literals illegal, when followed by PRI or SCN

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -702,8 +702,10 @@
         'name': 'constant.other.placeholder.c'
       }
       {
-        'match': '%'
-        'name': 'invalid.illegal.placeholder.c'
+        'match': '(%)(?!"\\s*(PRI)|(SCN))'
+        'captures':
+          '1':
+            'name': 'invalid.illegal.placeholder.c'
       }
     ]
   'preprocessor-rule-conditional':

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -702,7 +702,7 @@
         'name': 'constant.other.placeholder.c'
       }
       {
-        'match': '(%)(?!"\\s*(PRI)|(SCN))'
+        'match': '(%)(?!"\\s*(PRI|SCN))'
         'captures':
           '1':
             'name': 'invalid.illegal.placeholder.c'

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -92,6 +92,26 @@ describe "Language-C", ->
           expect(tokens[4]).toEqual value: 'b', scopes: ['source.c', scope]
           expect(tokens[5]).toEqual value: delim, scopes: ['source.c', scope, 'punctuation.definition.string.end.c']
 
+        {tokens} = grammar.tokenizeLine '"%d"'
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.c', 'string.quoted.double.c', 'punctuation.definition.string.begin.c']
+        expect(tokens[1]).toEqual value: '%d', scopes: ['source.c', 'string.quoted.double.c', 'constant.other.placeholder.c']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.c', 'string.quoted.double.c', 'punctuation.definition.string.end.c']
+
+        {tokens} = grammar.tokenizeLine '"%"'
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.c', 'string.quoted.double.c', 'punctuation.definition.string.begin.c']
+        expect(tokens[1]).toEqual value: '%', scopes: ['source.c', 'string.quoted.double.c', 'invalid.illegal.placeholder.c']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.c', 'string.quoted.double.c', 'punctuation.definition.string.end.c']
+
+        {tokens} = grammar.tokenizeLine '"%" PRId32'
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.c', 'string.quoted.double.c', 'punctuation.definition.string.begin.c']
+        expect(tokens[1]).toEqual value: '%', scopes: ['source.c', 'string.quoted.double.c']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.c', 'string.quoted.double.c', 'punctuation.definition.string.end.c']
+
+        {tokens} = grammar.tokenizeLine '"%" SCNd32'
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.c', 'string.quoted.double.c', 'punctuation.definition.string.begin.c']
+        expect(tokens[1]).toEqual value: '%', scopes: ['source.c', 'string.quoted.double.c']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.c', 'string.quoted.double.c', 'punctuation.definition.string.end.c']
+
     describe "comments", ->
       it "tokenizes them", ->
         {tokens} = grammar.tokenizeLine '/**/'


### PR DESCRIPTION
### Description of the Change

Currently `%` symbols in string constants, that are not followed by a valid `printf` specifier, are marked as illegal (i.e. get a red background signalling the developer something is wrong). However with integers of specified size you should use pre processor macros for the correct `printf` format.
```C
int32_t x = 3;
printf("x = %" PRId32, x);
```
In the above code the last character of the string is marked as illegal even though this is be the standard way to print an `int32_t`. This pull request makes sure a `%` does not get marked as illegal when its followed by a `printf`/`scanf` macro from `inttypes.h`.

### Alternate Designs
Alternatively the marking could be removed entirely as its incorrect when using any non-printf function (like `puts`, or one of the `str***` functions) anyway.

### Benefits
No more incorrect signalling red background in completely fine code.

### Possible Drawbacks
*none*

### Applicable Issues
Printing or scanning a fixed size integer.
