### PR TITLE
Make 'nullptr' a constant instead of a variable

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -54,7 +54,7 @@
   }
   {
     'match': '\\bnullptr\\b'
-    'name': 'variable.language.cpp'
+    'name': 'constant.language.cpp'
   }
   {
     'match': '\\btemplate\\b\\s*'


### PR DESCRIPTION
### Requirements
* none
### Description of the Change

With this PR the C++ keyword `nullptr` is correctly detected as constant (just like `NULL`), instead of as variable.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
