### PR TITLE
Fix issue #217

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -65,6 +65,10 @@
     'name': 'keyword.operator.cast.cpp'
   }
   {
+    'match': '::'
+    'name': 'punctuation.separator.namespace.access.cpp'
+  }
+  {
     'match': '\\b(and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\b'
     'name': 'keyword.operator.cpp'
   }

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -617,7 +617,7 @@
         'beginCaptures':
           '0':
             'name': 'keyword.operator.ternary.c'
-        'end': ':'
+        'end': '(?<!:):(?!:)'
         'endCaptures':
           '0':
             'name': 'keyword.operator.ternary.c'

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -617,7 +617,8 @@
         'beginCaptures':
           '0':
             'name': 'keyword.operator.ternary.c'
-        'end': '(?<!:):(?!:)'
+        'end': ':'
+        'applyEndPatternLast': true
         'endCaptures':
           '0':
             'name': 'keyword.operator.ternary.c'
@@ -632,7 +633,7 @@
             'include': '#c_function_call'
           }
           {
-            'include': '$self'
+            'include': '$base'
           }
         ]
       }

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -618,7 +618,7 @@
           '0':
             'name': 'keyword.operator.ternary.c'
         'end': ':'
-        'applyEndPatternLast': true
+        'applyEndPatternLast': true # To prevent matching C++ namespace access ::
         'endCaptures':
           '0':
             'name': 'keyword.operator.ternary.c'

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -907,6 +907,14 @@ describe "Language-C", ->
         expect(tokens[8]).toEqual value: ':', scopes: ['source.c', 'keyword.operator.ternary.c']
         expect(tokens[9]).toEqual value: ' c', scopes: ['source.c']
 
+      it "tokenizes ternary operators with namespace resolution", ->
+        {tokens} = grammar.tokenizeLine('a ? ns::b : ns::c')
+        expect(tokens[0]).toEqual value: 'a ', scopes: ['source.c']
+        expect(tokens[1]).toEqual value: '?', scopes: ['source.c', 'keyword.operator.ternary.c']
+        expect(tokens[2]).toEqual value: ' ns::b ', scopes: ['source.c']
+        expect(tokens[3]).toEqual value: ':', scopes: ['source.c', 'keyword.operator.ternary.c']
+        expect(tokens[4]).toEqual value: ' ns::c', scopes: ['source.c']
+
       describe "bitwise", ->
         it "tokenizes bitwise 'not'", ->
           {tokens} = grammar.tokenizeLine('~a')

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -907,14 +907,6 @@ describe "Language-C", ->
         expect(tokens[8]).toEqual value: ':', scopes: ['source.c', 'keyword.operator.ternary.c']
         expect(tokens[9]).toEqual value: ' c', scopes: ['source.c']
 
-      it "tokenizes ternary operators with namespace resolution", ->
-        {tokens} = grammar.tokenizeLine('a ? ns::b : ns::c')
-        expect(tokens[0]).toEqual value: 'a ', scopes: ['source.c']
-        expect(tokens[1]).toEqual value: '?', scopes: ['source.c', 'keyword.operator.ternary.c']
-        expect(tokens[2]).toEqual value: ' ns::b ', scopes: ['source.c']
-        expect(tokens[3]).toEqual value: ':', scopes: ['source.c', 'keyword.operator.ternary.c']
-        expect(tokens[4]).toEqual value: ' ns::c', scopes: ['source.c']
-
       describe "bitwise", ->
         it "tokenizes bitwise 'not'", ->
           {tokens} = grammar.tokenizeLine('~a')
@@ -1106,3 +1098,16 @@ describe "Language-C", ->
         expect(lines[1][0]).toEqual value: '//', scopes: ['source.cpp', 'comment.line.double-slash.cpp', 'punctuation.definition.comment.cpp']
         expect(lines[1][1]).toEqual value: ' not separated\\ ', scopes: ['source.cpp', 'comment.line.double-slash.cpp']
         expect(lines[2][0]).toEqual value: 'comment', scopes: ['source.cpp']
+
+    describe "operators", ->
+      it "tokenizes ternary operators with namespace resolution", ->
+        {tokens} = grammar.tokenizeLine('a ? ns::b : ns::c')
+        expect(tokens[0]).toEqual value: 'a ', scopes: ['source.cpp']
+        expect(tokens[1]).toEqual value: '?', scopes: ['source.cpp', 'keyword.operator.ternary.c']
+        expect(tokens[2]).toEqual value: ' ns', scopes: ['source.cpp']
+        expect(tokens[3]).toEqual value: '::', scopes: ['source.cpp', 'punctuation.separator.namespace.access.cpp']
+        expect(tokens[4]).toEqual value: 'b ', scopes: ['source.cpp']
+        expect(tokens[5]).toEqual value: ':', scopes: ['source.cpp', 'keyword.operator.ternary.c']
+        expect(tokens[6]).toEqual value: ' ns', scopes: ['source.cpp']
+        expect(tokens[7]).toEqual value: '::', scopes: ['source.cpp', 'punctuation.separator.namespace.access.cpp']
+        expect(tokens[8]).toEqual value: 'c', scopes: ['source.cpp']


### PR DESCRIPTION
### Description of the Change
Restrict the _ternary else operator_ `:` to only be matched for a single `:` character (not match `::` - _which is indeed invalid_). 

### Alternate Designs
None.

### Benefits
Will allow the _namespace operator_  `::` to be usable in _ternary conditionals_ in cpp grammar.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #217 