### PR TITLE
:bug: Fix #227

### DIFF
--- a/settings/language-c.cson
+++ b/settings/language-c.cson
@@ -16,4 +16,4 @@
       '
 '.source.c, .source.cpp':
   'editor':
-    'foldEndPattern': '(?<!\\*)\\*\\*/|^\\s*\\}'
+    'foldEndPattern': '(?<!\\*)\\*\\}'


### PR DESCRIPTION
Fix #227 by change `foldEndPattrn` from `(?<!\\*)\\*\\*/|^\\s*\\}` to `(?<!\\*)\\*\\}`