### PR TITLE
Fix namespaces not matched in inheritance lists

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -281,7 +281,7 @@
         ]
       }
       {
-        'begin': '\\b(class|struct)\\b\\s*([_A-Za-z][_A-Za-z0-9]*\\b)?+(\\s*:\\s*(public|protected|private)\\s*([_A-Za-z][_A-Za-z0-9]*\\b)((\\s*,\\s*(public|protected|private)\\s*[_A-Za-z][_A-Za-z0-9]*\\b)*))?'
+        'begin': '\\b(class|struct)\\b\\s*([_A-Za-z][_A-Za-z0-9]*\\b)?+(\\s*:\\s*(public|protected|private)\\s*((?:[_A-Za-z][_A-Za-z0-9]*\\b::)*[_A-Za-z][_A-Za-z0-9]*\\b)((\\s*,\\s*(public|protected|private)\\s*([_A-Za-z][_A-Za-z0-9]*\\b::)*[_A-Za-z][_A-Za-z0-9]*\\b)*))?'
         'beginCaptures':
           '1':
             'name': 'storage.type.cpp'
@@ -298,7 +298,7 @@
                 'name': 'storage.type.modifier.cpp'
               }
               {
-                'match': '[_A-Za-z][_A-Za-z0-9]*'
+                'match': '([_A-Za-z][_A-Za-z0-9]*\\b::)*[_A-Za-z][_A-Za-z0-9]*'
                 'name': 'entity.name.type.inherited.cpp'
               }
             ]


### PR DESCRIPTION
### Description of the Change

As reported in #81, a namespace string before the actual name of an inherited class results in no highlighting being applied. Further, this breaks all of the highlighting if a second (third...) base class name follows (polymorphism). An example can be found in #81.

I tracked down the issue and it's apparently based around the fact that namespaces are not accounted for in the respective regular expression, which means that if they do occur, the expression fails and nothing is highlighted.

This PR is a quick fix for that. It introduces the following RegEx part where necessary, thereby including the namespace in the class name match: `([_A-Za-z][_A-Za-z0-9]*\\b::)*`.

### Alternate Designs

It is possible that this is not the preferred behavior; perhaps the namespace should not simply be included in the class name (as this means they are both highlighted). In that case, feel free to propose a change. I'm not comfortable enough with the grammar file format or with this project's goals to implement something more sophisticated.

### Benefits

Highlighting is not broken by namespaced classes in a class's inheritance list.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #81.
