### PR TITLE
Fix #226

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -409,7 +409,13 @@
               (hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier
               [diouxXDOUeEfFgGaACcSspn%]           # conversion type
             '''
-            'name': 'constant.other.placeholder.cpp'
+            'name': 'constant.other.placeholder.c'
+          }
+          {
+            'match': '(%)(?!"\\s*(PRI|SCN))'
+            'captures':
+              '1':
+                'name': 'invalid.illegal.placeholder.c'
           }
         ]
       }

--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -400,22 +400,7 @@
             'name': 'constant.character.escape.cpp'
           }
           {
-            'match': '''(?x) %
-              (\\d+\\$)?                           # field (argument #)
-              [#0\\- +']*                          # flags
-              [,;:_]?                              # separator character (AltiVec)
-              ((-?\\d+)|\\*(-?\\d+\\$)?)?          # minimum field width
-              (\\.((-?\\d+)|\\*(-?\\d+\\$)?)?)?    # precision
-              (hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier
-              [diouxXDOUeEfFgGaACcSspn%]           # conversion type
-            '''
-            'name': 'constant.other.placeholder.c'
-          }
-          {
-            'match': '(%)(?!"\\s*(PRI|SCN))'
-            'captures':
-              '1':
-                'name': 'invalid.illegal.placeholder.c'
+            'include': 'source.c#string_placeholder'
           }
         ]
       }

--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -399,6 +399,18 @@
             'match': '\\\\x\\h+'
             'name': 'constant.character.escape.cpp'
           }
+          {
+            'match': '''(?x) %
+              (\\d+\\$)?                           # field (argument #)
+              [#0\\- +']*                          # flags
+              [,;:_]?                              # separator character (AltiVec)
+              ((-?\\d+)|\\*(-?\\d+\\$)?)?          # minimum field width
+              (\\.((-?\\d+)|\\*(-?\\d+\\$)?)?)?    # precision
+              (hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier
+              [diouxXDOUeEfFgGaACcSspn%]           # conversion type
+            '''
+            'name': 'constant.other.placeholder.cpp'
+          }
         ]
       }
       {

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -1018,6 +1018,22 @@ describe "Language-C", ->
       expect(lines[0][11]).toEqual value: '"', scopes: ['source.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.end.cpp']
       expect(lines[0][12]).toEqual value: ';', scopes: ['source.cpp', 'punctuation.terminator.statement.c']
 
+    it "tokenizes % format specifiers", ->
+      {tokens} = grammar.tokenizeLine '"%d"'
+      expect(tokens[0]).toEqual value: '"', scopes: ['source.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.begin.cpp']
+      expect(tokens[1]).toEqual value: '%d', scopes: ['source.cpp', 'string.quoted.double.cpp', 'constant.other.placeholder.c']
+      expect(tokens[2]).toEqual value: '"', scopes: ['source.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.end.cpp']
+
+      {tokens} = grammar.tokenizeLine '"%"'
+      expect(tokens[0]).toEqual value: '"', scopes: ['source.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.begin.cpp']
+      expect(tokens[1]).toEqual value: '%', scopes: ['source.cpp', 'string.quoted.double.cpp', 'invalid.illegal.placeholder.c']
+      expect(tokens[2]).toEqual value: '"', scopes: ['source.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.end.cpp']
+
+      {tokens} = grammar.tokenizeLine '"%" PRId32'
+      expect(tokens[0]).toEqual value: '"', scopes: ['source.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.begin.cpp']
+      expect(tokens[1]).toEqual value: '%', scopes: ['source.cpp', 'string.quoted.double.cpp']
+      expect(tokens[2]).toEqual value: '"', scopes: ['source.cpp', 'string.quoted.double.cpp', 'punctuation.definition.string.end.cpp']
+
     it "tokenizes raw string literals", ->
       lines = grammar.tokenizeLines '''
         string str = R"test(


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

With this PR you can change the format specifier color when the syntax is C++.

### Alternate Designs

None

### Benefits

Allow to change the format specifier color like `%d`, when the syntax is C++.

### Possible Drawbacks

None

### Applicable Issues

#226
