### PR TITLE
Prevent grammar endless loop with preprocessor rules

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -753,7 +753,7 @@
             'name': 'punctuation.definition.directive.c'
         'patterns': [
           {
-            'begin': '\\G(?=.)'
+            'begin': '\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))'
             'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
             'name': 'meta.preprocessor.c'
             'patterns': [
@@ -821,7 +821,7 @@
             'name': 'punctuation.definition.directive.c'
         'patterns': [
           {
-            'begin': '\\G(?=.)'
+            'begin': '\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))'
             'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
             'name': 'meta.preprocessor.c'
             'patterns': [
@@ -954,7 +954,7 @@
             'name': 'punctuation.definition.directive.c'
         'patterns': [
           {
-            'begin': '\\G(?=.)'
+            'begin': '\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))'
             'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?=\\n)'
             'name': 'meta.preprocessor.c'
             'patterns': [
@@ -987,7 +987,7 @@
             'end': '(?=^\\s*((#)\\s*(?:elif|else|endif)\\b))'
             'patterns': [
               {
-                'begin': '\\G(?=.)'
+                'begin': '\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))'
                 'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
                 'name': 'meta.preprocessor.c'
                 'patterns': [
@@ -1038,7 +1038,7 @@
             'name': 'punctuation.definition.directive.c'
         'patterns': [
           {
-            'begin': '\\G(?=.)'
+            'begin': '\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))'
             'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?=\\n)'
             'name': 'meta.preprocessor.c'
             'patterns': [
@@ -1071,7 +1071,7 @@
             'end': '(?=^\\s*((#)\\s*(?:elif|else|endif)\\b))'
             'patterns': [
               {
-                'begin': '\\G(?=.)'
+                'begin': '\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))'
                 'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
                 'name': 'meta.preprocessor.c'
                 'patterns': [
@@ -1113,7 +1113,7 @@
     'end': '(?=^\\s*((#)\\s*(?:elif|else|endif)\\b))'
     'patterns': [
       {
-        'begin': '\\G(?=.)'
+        'begin': '\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))'
         'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
         'name': 'meta.preprocessor.c'
         'patterns': [
@@ -1162,7 +1162,7 @@
             'name': 'punctuation.definition.directive.c'
         'patterns': [
           {
-            'begin': '\\G(?=.)'
+            'begin': '\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))'
             'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?=\\n)'
             'name': 'meta.preprocessor.c'
             'patterns': [
@@ -1247,7 +1247,7 @@
             'name': 'punctuation.definition.directive.c'
         'patterns': [
           {
-            'begin': '\\G(?=.)'
+            'begin': '\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))'
             'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?=\\n)'
             'name': 'meta.preprocessor.c'
             'patterns': [
@@ -1323,7 +1323,7 @@
     'end': '(?=^\\s*((#)\\s*endif\\b))'
     'patterns': [
       {
-        'begin': '\\G(?=.)'
+        'begin': '\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))'
         'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
         'name': 'meta.preprocessor.c'
         'patterns': [
@@ -1397,7 +1397,7 @@
     'end': '(?=^\\s*((#)\\s*endif\\b))'
     'patterns': [
       {
-        'begin': '\\G(?=.)'
+        'begin': '\\G(?=.)(?!//|/\\*(?!.*\\\\\\s*\\n))'
         'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
         'name': 'meta.preprocessor.c'
         'patterns': [

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -753,7 +753,7 @@
             'name': 'punctuation.definition.directive.c'
         'patterns': [
           {
-            'begin': '\\G'
+            'begin': '\\G(?=.)'
             'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
             'name': 'meta.preprocessor.c'
             'patterns': [
@@ -821,7 +821,7 @@
             'name': 'punctuation.definition.directive.c'
         'patterns': [
           {
-            'begin': '\\G'
+            'begin': '\\G(?=.)'
             'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
             'name': 'meta.preprocessor.c'
             'patterns': [
@@ -954,7 +954,7 @@
             'name': 'punctuation.definition.directive.c'
         'patterns': [
           {
-            'begin': '\\G'
+            'begin': '\\G(?=.)'
             'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?=\\n)'
             'name': 'meta.preprocessor.c'
             'patterns': [
@@ -987,7 +987,7 @@
             'end': '(?=^\\s*((#)\\s*(?:elif|else|endif)\\b))'
             'patterns': [
               {
-                'begin': '\\G'
+                'begin': '\\G(?=.)'
                 'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
                 'name': 'meta.preprocessor.c'
                 'patterns': [
@@ -1038,7 +1038,7 @@
             'name': 'punctuation.definition.directive.c'
         'patterns': [
           {
-            'begin': '\\G'
+            'begin': '\\G(?=.)'
             'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?=\\n)'
             'name': 'meta.preprocessor.c'
             'patterns': [
@@ -1071,7 +1071,7 @@
             'end': '(?=^\\s*((#)\\s*(?:elif|else|endif)\\b))'
             'patterns': [
               {
-                'begin': '\\G'
+                'begin': '\\G(?=.)'
                 'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
                 'name': 'meta.preprocessor.c'
                 'patterns': [
@@ -1113,7 +1113,7 @@
     'end': '(?=^\\s*((#)\\s*(?:elif|else|endif)\\b))'
     'patterns': [
       {
-        'begin': '\\G'
+        'begin': '\\G(?=.)'
         'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
         'name': 'meta.preprocessor.c'
         'patterns': [
@@ -1162,7 +1162,7 @@
             'name': 'punctuation.definition.directive.c'
         'patterns': [
           {
-            'begin': '\\G'
+            'begin': '\\G(?=.)'
             'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?=\\n)'
             'name': 'meta.preprocessor.c'
             'patterns': [
@@ -1247,7 +1247,7 @@
             'name': 'punctuation.definition.directive.c'
         'patterns': [
           {
-            'begin': '\\G'
+            'begin': '\\G(?=.)'
             'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?=\\n)'
             'name': 'meta.preprocessor.c'
             'patterns': [
@@ -1323,7 +1323,7 @@
     'end': '(?=^\\s*((#)\\s*endif\\b))'
     'patterns': [
       {
-        'begin': '\\G'
+        'begin': '\\G(?=.)'
         'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
         'name': 'meta.preprocessor.c'
         'patterns': [
@@ -1397,7 +1397,7 @@
     'end': '(?=^\\s*((#)\\s*endif\\b))'
     'patterns': [
       {
-        'begin': '\\G'
+        'begin': '\\G(?=.)'
         'end': '(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)'
         'name': 'meta.preprocessor.c'
         'patterns': [


### PR DESCRIPTION
The fix adds a positive lookahead to only enter the `meta.preprocessor.c` rule if there is at least one character to consume.
As both start and end rules do not consume any characters, this rule can be considered an endless loop.
While the Atom textmate engine seems to not be affected by this, the VSCode textmate engine has problems that lead to highlight issues.

#218 has more details