### PR TITLE
:bug: Fix alignof and typeid scope

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -266,7 +266,7 @@
   {
     # FIRST CAPTURE meta.function.c scope (provides an injectable scope, balanced parentheses and prevents unnecessary scope nesting)
     'begin': '''(?x)
-      (?!(?:while|for|do|if|else|switch|catch|enumerate|return|sizeof|[cr]?iterate|asm|__asm__|auto|bool|_Bool|char|_Complex|double|enum|float|_Imaginary|int|long|short|signed|struct|typedef|union|unsigned|void)\\s*\\()
+      (?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|asm|__asm__|auto|bool|_Bool|char|_Complex|double|enum|float|_Imaginary|int|long|short|signed|struct|typedef|union|unsigned|void)\\s*\\()
       (?=
         (?:[A-Za-z_][A-Za-z0-9_]*+|::)++\\s*\\(  # actual name
         |
@@ -398,7 +398,7 @@
   'c_function_call':
     # FIRST CAPTURE meta.function-call.c scope (provides an injectable scope, balanced parentheses and prevents unnecessary scope nesting)
     'begin': '''(?x)
-      (?!(?:while|for|do|if|else|switch|catch|enumerate|return|sizeof|[cr]?iterate)\\s*\\()
+      (?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate)\\s*\\()
       (?=
       (?:[A-Za-z_][A-Za-z0-9_]*+|::)++\\s*\\(  # actual name
       |
@@ -1523,7 +1523,7 @@
         # Function scope patterns for #define lines (terminates at newline w/o line_continuation_character)
         # FIRST CAPTURE meta.function.c scope (provides an injectable scope, balanced parentheses and prevents unnecessary scope nesting)
         'begin': '''(?x)
-          (?!(?:while|for|do|if|else|switch|catch|enumerate|return|sizeof|[cr]?iterate|asm|__asm__|auto|bool|_Bool|char|_Complex|double|enum|float|_Imaginary|int|long|short|signed|struct|typedef|union|unsigned|void)\\s*\\()
+          (?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|asm|__asm__|auto|bool|_Bool|char|_Complex|double|enum|float|_Imaginary|int|long|short|signed|struct|typedef|union|unsigned|void)\\s*\\()
           (?=
             (?:[A-Za-z_][A-Za-z0-9_]*+|::)++\\s*\\(  # actual name
             |
@@ -1636,7 +1636,7 @@
       {
         # Function patterns in #define lines (terminates at newline w/o line_continuation_character)
         'begin': '''(?x)
-          (?!(?:while|for|do|if|else|switch|catch|enumerate|return|sizeof|[cr]?iterate)\\s*\\()
+          (?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate)\\s*\\()
           (
           (?:[A-Za-z_][A-Za-z0-9_]*+|::)++  # actual name
           |
@@ -1696,7 +1696,7 @@
       }
       {
         'begin': '''(?x)
-          (?!(?:while|for|do|if|else|switch|catch|enumerate|return|sizeof|[cr]?iterate)\\s*\\()
+          (?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate)\\s*\\()
           (
           (?:[A-Za-z_][A-Za-z0-9_]*+|::)++  # actual name
           |
@@ -1754,7 +1754,7 @@
       }
       {
         'begin': '''(?x)
-          (?!(?:while|for|do|if|else|switch|catch|enumerate|return|sizeof|[cr]?iterate)\\s*\\()
+          (?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate)\\s*\\()
           (
           (?:[A-Za-z_][A-Za-z0-9_]*+|::)++  # actual name
           |


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Fix #238, the scope of `alignof` and `typeid` are correctly, but I don't know how to fix the `alignas` scope.

### Alternate Designs

None

### Benefits

Correct scope of `alignof` and `typeid`

### Possible Drawbacks

None

### Applicable Issues

#238
