### PR TITLE
Fix #240

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -36,7 +36,7 @@
     'name': 'storage.modifier.cpp'
   }
   {
-    'match': '\\b(catch|operator|try|throw|using)\\b'
+    'match': '\\b(catch|try|throw|using)\\b'
     'name': 'keyword.control.cpp'
   }
   {
@@ -79,6 +79,27 @@
   {
     'match': '\\b(constexpr|export|mutable|typename|thread_local)\\b'
     'name': 'storage.modifier.cpp'
+  }
+  {
+    'begin': '''(?x)
+      ((?:[A-Za-z_][A-Za-z0-9_]*::)*+\\boperator[-+*/%^&|~!=<>]|[-+*/%^&|=!<>]=|<<=?|>>=?|&&|\\|\\||\\+\\+|--|,|->\\*?|\\(\\)|\\[\\]|"") # operator method name
+      \\s*(\\() # opening bracket
+    '''
+    'beginCaptures':
+      '1':
+        'name': 'entity.name.function.cpp'
+      '2':
+        'name': 'punctuation.section.parameters.begin.bracket.round.c'
+    'end': '\\)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.parameters.end.bracket.round.c'
+    'name': 'meta.function.cpp',
+    'patterns': [
+      {
+        'include': '$base'
+      }
+    ]
   }
   {
     'begin': '''(?x)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Fix #240 the scope of operator function name are correctly.

### Alternate Designs

None

### Benefits

Correctly operator function scope like `T operator+(const T &l, const T &r);`.

### Possible Drawbacks

None

### Applicable Issues

#240
