### PR TITLE
Add ".xpm" to list of C file extensions

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -2,6 +2,7 @@
 'fileTypes': [
   'c'
   'h.in'
+  'xpm'
 ]
 'firstLineMatch': '(?i)-\\*-[^*]*(Mode:\\s*)?C(\\s*;.*?)?\\s*-\\*-'
 'name': 'C'


### PR DESCRIPTION
### Description of the Change

This is, uh... an "image" format written in C. As in, [literally](https://raw.githubusercontent.com/graemeg/freepascal/ae38cbc2d8a20fc3e6059ee7d77916efcb4fed1b/packages/xforms/examples/crab.xpm).

Apparently, [it's a historic extension](https://en.wikipedia.org/wiki/X_PixMap)... but there are over a [million of 'em hanging around](https://github.com/search?o=asc&q=extension%3Axpm+NOT+nothack&s=indexed&type=Code) on GitHub, so I guess the format must still get *some* mileage.

### Alternate Designs

I tried adding Radiance HDR in a similar fashion, and successfully bricked my computer. 👍 

### Benefits

People might take this format seriously? I'm still laughing.

### Possible Drawbacks

People might use this format?

### Applicable Issues

I love you guys.
