### PR TITLE
fix scanf snippet

### DIFF
--- a/snippets/language-c.cson
+++ b/snippets/language-c.cson
@@ -58,7 +58,7 @@
     'body': 'printf("${1:%s}\\\\n", $2);$3'
   'scanf':
     'prefix': 'scanf'
-    'body': 'scanf(\"${1:%s}\\\\n\", $2);$3'
+    'body': 'scanf(\"${1:%s}\\\\", $2);$3'
   'Struct':
     'prefix': 'st'
     'body': 'struct ${1:name_t} {\n\t${2:/* data */}\n};'


### PR DESCRIPTION
### Requirements

Fix bag
In "scanf", don't use "\n"
if it is used, it will become error.

### Description of the Change

There is no new Description. Only bag fix.

### Alternate Designs

It was troublesome to correct each time.

### Benefits

There is no need to erase each "\ n" when using "scanf"

### Possible Drawbacks

Nothing

### Applicable Issues

Nothing