### PR TITLE
Improve #error and #warning tokenization

### DIFF
--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -94,8 +94,8 @@
     ]
   }
   {
-    'begin': '^\\s*((#)\\s*(error|warning))\\b'
-    'captures':
+    'begin': '^\\s*((#)\\s*(error|warning))\\b\\s*'
+    'beginCaptures':
       '1':
         'name': 'keyword.control.directive.diagnostic.$3.c'
       '2':
@@ -104,7 +104,52 @@
     'name': 'meta.preprocessor.diagnostic.c'
     'patterns': [
       {
-        'include': '#line_continuation_character'
+        # double quoted string patterns for #error/warning lines (terminates at newline w/o line_continuation_character)
+        'begin': '"'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.c'
+        'end': '"|(?<!\\\\)(?=\\s*\\n)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.c'
+        'name': 'string.quoted.double.c'
+        'patterns': [
+          {
+            'include': '#line_continuation_character'
+          }
+        ]
+      }
+      {
+        # single quoted string patterns for #error/warning lines (terminates at newline w/o line_continuation_character)
+        'begin': '\''
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.c'
+        'end': '\'|(?<!\\\\)(?=\\s*\\n)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.c'
+        'name': 'string.quoted.single.c'
+        'patterns': [
+          {
+            'include': '#line_continuation_character'
+          }
+        ]
+      }
+      {
+        # unquoted strings patterns for #error/warning lines (terminates at newline w/o line_continuation_character)
+        'begin': '[^\'"]'
+        'end': '(?<!\\\\)(?=\\s*\\n)'
+        'name': 'string.unquoted.single.c'
+        'patterns': [
+          {
+            'include': '#line_continuation_character'
+          }
+          {
+            'include': '#comments'
+          }
+        ]
       }
     ]
   }

--- a/grammars/c.cson
+++ b/grammars/c.cson
@@ -100,15 +100,9 @@
         'name': 'keyword.control.directive.diagnostic.$3.c'
       '2':
         'name': 'punctuation.definition.directive.c'
-    'end': '(?<!\\\\)(?=\\n)|(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))'
+    'end': '(?<!\\\\)(?=\\n)'
     'name': 'meta.preprocessor.diagnostic.c'
     'patterns': [
-      {
-        'include': '#comments'
-      }
-      {
-        'include': '#strings'
-      }
       {
         'include': '#line_continuation_character'
       }


### PR DESCRIPTION
Fix highlight of error directive

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This treats text following warning and error as plain text with no interpretation.

There is one flaw with #233:
From: https://gcc.gnu.org/onlinedocs/cpp/Diagnostics.html
'The line must consist of complete tokens. It is wisest to make the argument of these directives be a single string constant; this avoids problems with apostrophes and the like.'

Unmatch token will generate compilation warning: 

```
fnadeau@foobar:~/github$ cat issue_233.c 
#warning "This is a warning"
#warning Well, you don't actually need quote
#warning "This is a multiple \ /* asdg */ \
int allo = 14;"

#error doesn't 

#error need "fixing

int j;

int main (void) {

  return 0;
}
fnadeau@foobar:~/github$ gcc issue_233.c -o issue_233
issue_233.c:1:2: warning: #warning "This is a warning" [-Wcpp]
 #warning "This is a warning"
  ^
issue_233.c:2:23: warning: missing terminating ' character [enabled by default]
 #warning Well, you don't actually need quote
                       ^
issue_233.c:2:2: warning: #warning Well, you don't actually need quote [-Wcpp]
 #warning Well, you don't actually need quote
  ^
issue_233.c:3:2: warning: #warning "This is a multiple \ /* asdg */ int allo = 14;" [-Wcpp]
 #warning "This is a multiple \ /* asdg */ \
  ^
issue_233.c:6:13: warning: missing terminating ' character [enabled by default]
 #error doesn't 
             ^
issue_233.c:6:2: error: #error doesn't 
 #error doesn't 
  ^
issue_233.c:8:13: warning: missing terminating " character [enabled by default]
 #error need "fixing
             ^
issue_233.c:8:2: error: #error need "fixing
 #error need "fixing
  ^
```
GCC does threat comments in a warning/error as the message and not has comment.

![issue_233](https://user-images.githubusercontent.com/1904563/32249704-4b423512-be60-11e7-8856-be4042a323f2.jpg)

### Alternate Designs

None

### Benefits

Fix highlight issue when unmatch token are in a error/warning comment

### Possible Drawbacks

None known.

### Applicable Issues

Fixes #233