### PR TITLE
Add tree-sitter grammars for C and C++

### DIFF
--- a/grammars/tree-sitter-c.cson
+++ b/grammars/tree-sitter-c.cson
@@ -2,6 +2,7 @@ id: 'c'
 name: 'C'
 type: 'tree-sitter'
 parser: 'tree-sitter-c'
+legacyScopeName: 'source.c'
 
 fileTypes: [
   'h'
@@ -9,20 +10,22 @@ fileTypes: [
   'h.in'
 ]
 
+legacyScopeName: 'source.c'
+
 folds: [
   {
     type: ['comment', 'preproc_arg']
   }
   {
-    type: ['preproc_if', 'preproc_ifdef'],
-    end: {type: 'preproc_else'}
+    type: ['preproc_if', 'preproc_ifdef', 'preproc_elif'],
+    end: {type: ['preproc_else', 'preproc_elif']}
   }
   {
     type: ['preproc_if', 'preproc_ifdef'],
     end: {index: -1}
   }
   {
-    type: ['preproc_else']
+    type: ['preproc_else', 'preproc_elif']
     start: {index: 0}
   }
   {
@@ -46,13 +49,13 @@ comments:
   start: '// '
 
 scopes:
-  'translation_unit': 'source.c'
   'comment': 'comment.block'
   # 'ERROR': 'syntax-error'
 
   '"#if"': 'keyword.control.directive'
   '"#ifdef"': 'keyword.control.directive'
   '"#ifndef"': 'keyword.control.directive'
+  '"#elif"': 'keyword.control.directive'
   '"#else"': 'keyword.control.directive'
   '"#endif"': 'keyword.control.directive'
   '"#define"': 'keyword.control.directive'

--- a/grammars/tree-sitter-c.cson
+++ b/grammars/tree-sitter-c.cson
@@ -9,20 +9,41 @@ fileTypes: [
   'h.in'
 ]
 
-folds:
-  delimiters: [
-    ['{', '}']
-    ['(', ')']
-    ['[', ']']
-  ]
-
-  nodes: [
-    'comment'
-    'preproc_arg'
-  ]
+folds: [
+  {
+    type: ['comment', 'preproc_arg']
+  }
+  {
+    type: ['preproc_if', 'preproc_ifdef'],
+    end: {type: 'preproc_else'}
+  }
+  {
+    type: ['preproc_if', 'preproc_ifdef'],
+    end: {index: -1}
+  }
+  {
+    type: ['preproc_else']
+    start: {index: 0}
+  }
+  {
+    type: [
+      'enumerator_list'
+      'compound_statement'
+      'field_declaration_list'
+      'parameter_list'
+      'argument_list'
+      'initializer_list'
+      'parenthesized_expression'
+      'template_parameter_list'
+      'template_argument_list'
+    ]
+    start: {index: 0}
+    end: {index: -1}
+  }
+]
 
 comments:
-  '// '
+  start: '// '
 
 scopes:
   'translation_unit': 'source.c'

--- a/grammars/tree-sitter-c.cson
+++ b/grammars/tree-sitter-c.cson
@@ -1,0 +1,88 @@
+id: 'c'
+name: 'C'
+type: 'tree-sitter'
+parser: 'tree-sitter-c'
+
+fileTypes: [
+  'h'
+  'c'
+  'h.in'
+]
+
+folds:
+  delimiters: [
+    ['{', '}']
+    ['(', ')']
+    ['[', ']']
+  ]
+
+  nodes: [
+    'comment'
+    'preproc_arg'
+  ]
+
+comments:
+  '// '
+
+scopes:
+  'translation_unit': 'source.c'
+  'comment': 'comment.block'
+  # 'ERROR': 'syntax-error'
+
+  '"#if"': 'keyword.control.directive'
+  '"#ifdef"': 'keyword.control.directive'
+  '"#ifndef"': 'keyword.control.directive'
+  '"#else"': 'keyword.control.directive'
+  '"#endif"': 'keyword.control.directive'
+  '"#define"': 'keyword.control.directive'
+  '"#include"': 'keyword.control.directive'
+
+  '"if"': 'keyword.control'
+  '"else"': 'keyword.control'
+  '"do"': 'keyword.control'
+  '"for"': 'keyword.control'
+  '"while"': 'keyword.control'
+  '"break"': 'keyword.control'
+  '"continue"': 'keyword.control'
+  '"return"': 'keyword.control'
+  '"switch"': 'keyword.control'
+  '"case"': 'keyword.control'
+  '"default"': 'keyword.control'
+
+  '"struct"': 'keyword.control'
+  '"enum"': 'keyword.control'
+  '"union"': 'keyword.control'
+  '"typedef"': 'keyword.control'
+
+  'preproc_function_def > identifier:nth-child(1)': 'entity.name.function.preprocessor'
+  'preproc_arg': 'meta.preprocessor.macro'
+
+  'call_expression > identifier': 'entity.name.function'
+  'call_expression > field_expression > field_identifier': 'entity.name.function'
+  'function_declarator > identifier': 'entity.name.function'
+
+  'field_identifier': 'variable.other.member'
+
+  'type_identifier': 'support.support.type'
+  'primitive_type': 'support.support.type'
+  '"unsigned"': 'support.support.type'
+
+  'string_literal': 'string.quoted.double'
+  'system_lib_string': 'string.quoted.other'
+
+  'number_literal': 'constant.numeric.decimal'
+  'null': 'constant.language.null'
+  'true': 'constant.language.boolean'
+  'false': 'constant.language.boolean'
+
+  'auto': 'storage.modifier'
+  '"static"': 'storage.modifier'
+  '"inline"': 'storage.modifier'
+  '"const"': 'storage.modifier'
+  'function_specifier': 'storage.modifier'
+
+  '"*"': 'keyword.operator'
+  '"&"': 'keyword.operator'
+  '"&&"': 'keyword.operator'
+  '"||"': 'keyword.operator'
+  '"|"': 'keyword.operator'

--- a/grammars/tree-sitter-c.cson
+++ b/grammars/tree-sitter-c.cson
@@ -32,6 +32,7 @@ folds: [
     type: [
       'enumerator_list'
       'compound_statement'
+      'declaration_list'
       'field_declaration_list'
       'parameter_list'
       'argument_list'

--- a/grammars/tree-sitter-c.cson
+++ b/grammars/tree-sitter-c.cson
@@ -101,6 +101,7 @@ scopes:
   'false': 'constant.language.boolean'
 
   'auto': 'storage.modifier'
+  '"extern"': 'storage.modifier'
   '"static"': 'storage.modifier'
   '"inline"': 'storage.modifier'
   '"const"': 'storage.modifier'
@@ -109,5 +110,5 @@ scopes:
   '"*"': 'keyword.operator'
   '"&"': 'keyword.operator'
   '"&&"': 'keyword.operator'
-  '"||"': 'keyword.operator'
   '"|"': 'keyword.operator'
+  '"||"': 'keyword.operator'

--- a/grammars/tree-sitter-cpp.cson
+++ b/grammars/tree-sitter-cpp.cson
@@ -1,0 +1,117 @@
+id: 'cpp'
+name: 'C++'
+type: 'tree-sitter'
+parser: 'tree-sitter-cpp'
+
+fileTypes: [
+  'cc'
+  'cpp'
+  'cp'
+  'cxx'
+  'c++'
+  'cu'
+  'cuh'
+  'h'
+  'hh'
+  'hpp'
+  'hxx'
+  'h++'
+  'inl'
+  'ino'
+  'ipp'
+  'tcc'
+  'tpp'
+]
+
+folds:
+  delimiters: [
+    ['{', '}']
+    ['(', ')']
+    ['[', ']']
+  ]
+
+  tokens: [
+    'comment'
+    'preproc_arg'
+  ]
+
+comments:
+  start: '// '
+
+scopes:
+  'translation_unit': 'source.cpp'
+  'comment': 'comment.block'
+  # 'ERROR': 'syntax-error'
+
+  '"#if"': 'keyword.control.directive'
+  '"#ifdef"': 'keyword.control.directive'
+  '"#ifndef"': 'keyword.control.directive'
+  '"#else"': 'keyword.control.directive'
+  '"#endif"': 'keyword.control.directive'
+  '"#define"': 'keyword.control.directive'
+  '"#include"': 'keyword.control.directive'
+
+  '"if"': 'keyword.control'
+  '"else"': 'keyword.control'
+  '"do"': 'keyword.control'
+  '"for"': 'keyword.control'
+  '"while"': 'keyword.control'
+  '"break"': 'keyword.control'
+  '"continue"': 'keyword.control'
+  '"return"': 'keyword.control'
+  '"switch"': 'keyword.control'
+  '"case"': 'keyword.control'
+  '"default"': 'keyword.control'
+
+  '"struct"': 'keyword.control'
+  '"enum"': 'keyword.control'
+  '"union"': 'keyword.control'
+  '"typedef"': 'keyword.control'
+  '"class"': 'keyword.control'
+  '"using"': 'keyword.control'
+  '"namespace"': 'keyword.control'
+  '"template"': 'keyword.control'
+  '"typename"': 'keyword.control'
+
+  'preproc_function_def > identifier:nth-child(1)': 'entity.name.function.preprocessor'
+  'preproc_arg': 'meta.preprocessor.macro'
+
+  'call_expression > identifier': 'entity.name.function'
+  'call_expression > field_expression > field_identifier': 'entity.name.function'
+  'call_expression > scoped_identifier > identifier': 'entity.name.function'
+  'template_function > identifier': 'entity.name.function'
+  'template_function > scoped_identifier > identifier': 'entity.name.function'
+  'function_declarator > identifier': 'entity.name.function'
+  'function_declarator > field_identifier': 'entity.name.function'
+  'function_declarator > scoped_identifier > identifier': 'entity.name.function'
+  'destructor_name > identifier': 'entity.name.function'
+
+  'field_identifier': 'variable.other.member'
+
+  'type_identifier': 'support.storage.type'
+  'primitive_type': 'support.storage.type'
+  '"unsigned"': 'support.storage.type'
+  'auto': 'storage.storage.type'
+
+  'string_literal': 'string.quoted.double'
+  'system_lib_string': 'string.quoted.other'
+
+  'number_literal': 'constant.numeric.decimal'
+  'null': 'constant.language.null'
+  'nullptr': 'constant.language.null'
+  'true': 'constant.language.boolean'
+  'false': 'constant.language.boolean'
+
+  '"static"': 'storage.modifier'
+  '"inline"': 'storage.modifier'
+  '"const"': 'storage.modifier'
+  'function_specifier': 'storage.modifier'
+  '"public"': 'storage.modifier'
+  '"private"': 'storage.modifier'
+  '"protected"': 'storage.modifier'
+
+  '"*"': 'keyword.operator'
+  '"&"': 'keyword.operator'
+  '"&&"': 'keyword.operator'
+  '"||"': 'keyword.operator'
+  '"|"': 'keyword.operator'

--- a/grammars/tree-sitter-cpp.cson
+++ b/grammars/tree-sitter-cpp.cson
@@ -98,6 +98,7 @@ scopes:
 
   'preproc_function_def > identifier:nth-child(1)': 'entity.name.function.preprocessor'
   'preproc_arg': 'meta.preprocessor.macro'
+  'preproc_directive': 'keyword.control.directive'
 
   'call_expression > identifier': 'entity.name.function'
   'call_expression > field_expression > field_identifier': 'entity.name.function'

--- a/grammars/tree-sitter-cpp.cson
+++ b/grammars/tree-sitter-cpp.cson
@@ -23,17 +23,38 @@ fileTypes: [
   'tpp'
 ]
 
-folds:
-  delimiters: [
-    ['{', '}']
-    ['(', ')']
-    ['[', ']']
-  ]
-
-  tokens: [
-    'comment'
-    'preproc_arg'
-  ]
+folds: [
+  {
+    type: ['comment', 'preproc_arg']
+  }
+  {
+    type: ['preproc_if', 'preproc_ifdef'],
+    end: {type: 'preproc_else'}
+  }
+  {
+    type: ['preproc_if', 'preproc_ifdef'],
+    end: {index: -1}
+  }
+  {
+    type: ['preproc_else']
+    start: {index: 0}
+  }
+  {
+    type: [
+      'enumerator_list'
+      'compound_statement'
+      'field_declaration_list'
+      'parameter_list'
+      'argument_list'
+      'initializer_list'
+      'parenthesized_expression'
+      'template_parameter_list'
+      'template_argument_list'
+    ]
+    start: {index: 0}
+    end: {index: -1}
+  }
+]
 
 comments:
   start: '// '

--- a/grammars/tree-sitter-cpp.cson
+++ b/grammars/tree-sitter-cpp.cson
@@ -127,6 +127,7 @@ scopes:
   'true': 'constant.language.boolean'
   'false': 'constant.language.boolean'
 
+  '"extern"': 'storage.modifier'
   '"static"': 'storage.modifier'
   '"inline"': 'storage.modifier'
   '"const"': 'storage.modifier'
@@ -135,8 +136,10 @@ scopes:
   '"private"': 'storage.modifier'
   '"protected"': 'storage.modifier'
 
+  '"new"': 'keyword.operator'
+  '"delete"': 'keyword.operator'
   '"*"': 'keyword.operator'
   '"&"': 'keyword.operator'
   '"&&"': 'keyword.operator'
-  '"||"': 'keyword.operator'
   '"|"': 'keyword.operator'
+  '"||"': 'keyword.operator'

--- a/grammars/tree-sitter-cpp.cson
+++ b/grammars/tree-sitter-cpp.cson
@@ -44,6 +44,7 @@ folds: [
     type: [
       'enumerator_list'
       'compound_statement'
+      'declaration_list'
       'field_declaration_list'
       'parameter_list'
       'argument_list'

--- a/grammars/tree-sitter-cpp.cson
+++ b/grammars/tree-sitter-cpp.cson
@@ -2,6 +2,7 @@ id: 'cpp'
 name: 'C++'
 type: 'tree-sitter'
 parser: 'tree-sitter-cpp'
+legacyScopeName: 'source.cpp'
 
 fileTypes: [
   'cc'
@@ -28,15 +29,15 @@ folds: [
     type: ['comment', 'preproc_arg']
   }
   {
-    type: ['preproc_if', 'preproc_ifdef'],
-    end: {type: 'preproc_else'}
+    type: ['preproc_if', 'preproc_ifdef', 'preproc_elif'],
+    end: {type: ['preproc_else', 'preproc_elif']}
   }
   {
     type: ['preproc_if', 'preproc_ifdef'],
     end: {index: -1}
   }
   {
-    type: ['preproc_else']
+    type: ['preproc_else', 'preproc_elif']
     start: {index: 0}
   }
   {
@@ -67,6 +68,7 @@ scopes:
   '"#if"': 'keyword.control.directive'
   '"#ifdef"': 'keyword.control.directive'
   '"#ifndef"': 'keyword.control.directive'
+  '"#elif"': 'keyword.control.directive'
   '"#else"': 'keyword.control.directive'
   '"#endif"': 'keyword.control.directive'
   '"#define"': 'keyword.control.directive'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.58.1",
+  "version": "0.59.0-0",
   "name": "language-c",
   "description": "Atom language support for C/C++",
   "homepage": "https://atom.github.io/language-c",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "atom": "*",
     "node": "*"
   },
+  "dependencies": {
+    "tree-sitter-c": "^0.4.5",
+    "tree-sitter-cpp": "^0.3.3"
+  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.59.0-1",
+  "version": "0.59.0-2",
   "name": "language-c",
   "description": "Atom language support for C/C++",
   "homepage": "https://atom.github.io/language-c",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.59.0-0",
+  "version": "0.59.0-1",
   "name": "language-c",
   "description": "Atom language support for C/C++",
   "homepage": "https://atom.github.io/language-c",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.59.0-2",
+  "version": "0.59.0-3",
   "name": "language-c",
   "description": "Atom language support for C/C++",
   "homepage": "https://atom.github.io/language-c",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "node": "*"
   },
   "dependencies": {
-    "tree-sitter-c": "^0.4.5",
-    "tree-sitter-cpp": "^0.3.3"
+    "tree-sitter-c": "^0.5.0",
+    "tree-sitter-cpp": "^0.4.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"


### PR DESCRIPTION
⚠️  Work In Progress ⚠️ 

This adds alternative C and C++ grammars that use [tree-sitter-c](https://github.com/tree-sitter/tree-sitter-c) and [tree-sitter-cpp](https://github.com/tree-sitter/tree-sitter-cpp) for parsing instead of [first-mate](https://github.com/atom/first-mate).