### PR TITLE
Fix C++ synatx highlighting error in macros with extern "C"

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -341,15 +341,15 @@
         'beginCaptures':
           '1':
             'name': 'storage.modifier.cpp'
-        'end': '(?<=\\})|(?=\\w)|(?=\\s*#\\s*endif\\b)'
+        'end': '(?<=})|(?=\\w)|(?=\\s*#\\s*(?:elif|else|endif)\\b)'
         'name': 'meta.extern-block.cpp'
         'patterns': [
           {
-            'begin': '\\{'
+            'begin': '{'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.block.begin.bracket.curly.c'
-            'end': '\\}|(?=\\s*#\\s*endif\\b)'
+            'end': '}|(?=\\s*#\\s*(?:elif|else|endif)\\b)'
             'endCaptures':
               '0':
                 'name': 'punctuation.section.block.end.bracket.curly.c'

--- a/spec/c-spec.coffee
+++ b/spec/c-spec.coffee
@@ -1001,6 +1001,16 @@ describe "Language-C", ->
       expect(lines[6][0]).toEqual value: '#', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c', 'punctuation.definition.directive.c']
       expect(lines[6][1]).toEqual value: 'endif', scopes: ['source.cpp', 'meta.preprocessor.c', 'keyword.control.directive.conditional.c']
 
+      lines = grammar.tokenizeLines '''
+        #ifdef __cplusplus
+        #define EXTERN extern "C"
+        #else
+        #define EXTERN extern
+        #endif
+      '''
+      # TODO
+      expect(lines).toEqual false
+
     it "tokenizes UTF string escapes", ->
       lines = grammar.tokenizeLines '''
         string str = U"\\U01234567\\u0123\\"\\0123\\x123";


### PR DESCRIPTION
### Description of the Change

Update the C++ grammar to fix syntax highlighting of `extern "C"` inside macros.

Example code:

```c++
#ifdef __cplusplus
    #define FOO_EXTERN extern "C"
#else
    #define FOO_EXTERN extern
#endif

```

Before this change:

![before](https://user-images.githubusercontent.com/4525736/38646706-da394cea-3e0a-11e8-86bf-c8b9cd9faac0.png)

After:

![after](https://user-images.githubusercontent.com/4525736/38646709-de509f68-3e0a-11e8-9407-95d25fc29c8f.png)

The two lines where I added `else` and `elif` are not strictly necessary for this patch to work, but since there is an `endif` I thought I was a good idea to have them there too. I'm not entirely sure where `endif` is there to be honest, this rule seems to work well without it.