### PR TITLE
Fix misleading scanf snippet

### DIFF
--- a/snippets/language-c.cson
+++ b/snippets/language-c.cson
@@ -58,7 +58,7 @@
     'body': 'printf("${1:%s}\\\\n", $2);$3'
   'scanf':
     'prefix': 'scanf'
-    'body': 'scanf(\"${1:%s}\\\\n\", $2);$3'
+    'body': 'scanf(\"\\\\n${1:%s}\", $2);$3'
   'Struct':
     'prefix': 'st'
     'body': 'struct ${1:name_t} {\n\t${2:/* data */}\n};'


### PR DESCRIPTION


### Requirements

Newlines at the end of a `scanf` format string consume the newline used to input something and thus forces the user to press Enter twice. Instead putting a newline at the beginning of the format string consumes any newlines lingering in the buffer thus is benefical.

### Description of the Change

The `scanf` snippet is changed from `scanf("%s\n", );` to `scanf("\n%s", );`.

### Alternate Designs

An alternative could be to just remove the trailing newline but putting it at the beginning of the format string is even better because it guards the programmer against spurious newlines in the input buffer.

### Benefits

This code change will lead to a better `scanf` snippet thus teaching all the atom users a new
and portable way to avoid common `scanf` bugs.

### Possible Drawbacks

None

### Applicable Issues

None
