### PR TITLE
Scope primitive types as support.storage.type instead of support.support.type

### DIFF
--- a/grammars/tree-sitter-c.cson
+++ b/grammars/tree-sitter-c.cson
@@ -97,11 +97,11 @@ scopes:
 
   'field_identifier': 'variable.other.member'
 
-  'type_identifier': 'support.support.type'
-  'primitive_type': 'support.support.type'
-  '"unsigned"': 'support.support.type'
-  '"short"': 'support.support.type'
-  '"long"': 'support.support.type'
+  'type_identifier': 'support.storage.type'
+  'primitive_type': 'support.storage.type'
+  '"unsigned"': 'support.storage.type'
+  '"short"': 'support.storage.type'
+  '"long"': 'support.storage.type'
 
   'char_literal': 'string.quoted.single'
   'string_literal': 'string.quoted.double'

--- a/grammars/tree-sitter-cpp.cson
+++ b/grammars/tree-sitter-cpp.cson
@@ -140,7 +140,7 @@ scopes:
   '"unsigned"': 'support.storage.type'
   '"short"': 'support.storage.type'
   '"long"': 'support.storage.type'
-  'auto': 'storage.storage.type'
+  'auto': 'support.storage.type'
 
   'char_literal': 'string.quoted.single'
   'string_literal': 'string.quoted.double'

--- a/grammars/tree-sitter-cpp.cson
+++ b/grammars/tree-sitter-cpp.cson
@@ -138,8 +138,8 @@ scopes:
   'type_identifier': 'support.storage.type'
   'primitive_type': 'support.storage.type'
   '"unsigned"': 'support.storage.type'
-  '"short"': 'support.support.type'
-  '"long"': 'support.support.type'
+  '"short"': 'support.storage.type'
+  '"long"': 'support.storage.type'
   'auto': 'storage.storage.type'
 
   'char_literal': 'string.quoted.single'


### PR DESCRIPTION
Refs https://github.com/atom/language-c/issues/299#issuecomment-434486674

The ones that work with fizzy are `support.storage.type` instead of `support.support.type`.

/cc: @maxbrunsfeld  I didn't test this change in Atom other than looking at the scopes in Atom and which are highlighted with fizzy. I'll test this out later today when I can link packages into Atom.