### PR TITLE
add static_assert, split operators

### DIFF
--- a/grammars/c++.cson
+++ b/grammars/c++.cson
@@ -69,8 +69,16 @@
     'name': 'punctuation.separator.namespace.access.cpp'
   }
   {
-    'match': '\\b(and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\b'
+    'match': '\\b(typeid|alignof|alignas)\\b'
     'name': 'keyword.operator.cpp'
+  }
+  {
+    'match': '\\b(and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|xor|xor_eq)\\b'
+    'name': 'keyword.operator.alias.cpp'
+  }
+  {
+    'match': '\\bstatic_assert\\b'
+    'name': 'keyword.static-assert.cpp'
   }
   {
     'match': '\\b(class|decltype|wchar_t|char16_t|char32_t)\\b'


### PR DESCRIPTION
### Description of the Change

- added regex to match c++'s `static_assert`
- the alternative operators `and`, `or`, `bitend`, etc moved to `keyword.operator.alias.cpp`

### Alternate Designs
None

### Benefits

 `static_assert` can now be colored as a keyword, as it should

the alternative operators can now be colored independently, Visual Studio (dark theme) for example colors these w/ a darker gray.

### Possible Drawbacks
None

### Applicable Issues

#246
