### PR TITLE
Scope anonymous " in a string as punctuation.definition.string

### DIFF
--- a/grammars/tree-sitter-c.cson
+++ b/grammars/tree-sitter-c.cson
@@ -139,7 +139,7 @@ scopes:
   '"]"': 'punctuation.definition.end.bracket.square'
   '","': 'punctuation.separator.delimiter'
   'char_literal > "\'"': 'punctuation.definition.string'
-  # 'string_literal > "\"': 'punctuation.definition.string' # TODO: Figure out why this doesn't work
+  'string_literal > "\\""': 'punctuation.definition.string'
   '"{"': 'punctuation.section.block.begin.bracket.curly'
   '"}"': 'punctuation.section.block.end.bracket.curly'
   '"("': 'punctuation.section.parens.begin.bracket.round'

--- a/grammars/tree-sitter-cpp.cson
+++ b/grammars/tree-sitter-cpp.cson
@@ -200,7 +200,7 @@ scopes:
   'template_argument_list > ">"': 'punctuation.definition.template.bracket.angle'
   'template_argument_list > "<"': 'punctuation.definition.template.bracket.angle'
   'char_literal > "\'"': 'punctuation.definition.string'
-  # 'string_literal > "\""': 'punctuation.definition.string' # TODO: Figure out why this doesn't work
+  'string_literal > "\\""': 'punctuation.definition.string'
   '"{"': 'punctuation.section.block.begin.bracket.curly'
   '"}"': 'punctuation.section.block.end.bracket.curly'
   '"("': 'punctuation.section.parens.begin.bracket.round'


### PR DESCRIPTION
### Description of the Change

This PR depends on https://github.com/atom/atom/pull/19336 to scope anonymous `"` nodes as `punctuation.definition.string`

### Alternate Designs

N/A

### Benefits

Closer to textmate

### Possible Drawbacks

No

### Applicable Issues

I don't think there is an issue open for this.

/cc: @chbk