### PR TITLE
Added `noexcept` and `mutable`, removed `_Atomic` from tree-sitter-cpp

### DIFF
--- a/grammars/tree-sitter-cpp.cson
+++ b/grammars/tree-sitter-cpp.cson
@@ -182,7 +182,6 @@ scopes:
   '"final"': 'storage.modifier'
   '"override"': 'storage.modifier'
   '"virtual"': 'storage.modifier'
-  '"noexcept"': 'storage.modifier'
   '"mutable"': 'storage.modifier'
 
   '";"': 'punctuation.terminator.statement'

--- a/grammars/tree-sitter-cpp.cson
+++ b/grammars/tree-sitter-cpp.cson
@@ -183,6 +183,7 @@ scopes:
   '"override"': 'storage.modifier'
   '"virtual"': 'storage.modifier'
   '"noexcept"': 'storage.modifier'
+  '"mutable"': 'storage.modifier'
 
   '";"': 'punctuation.terminator.statement'
   '"["': 'punctuation.definition.begin.bracket.square'

--- a/grammars/tree-sitter-cpp.cson
+++ b/grammars/tree-sitter-cpp.cson
@@ -175,7 +175,6 @@ scopes:
   '"constexpr"': 'storage.modifier'
   '"volatile"': 'storage.modifier'
   '"restrict"': 'storage.modifier'
-  '"_Atomic"': 'storage.modifier'
   'function_specifier': 'storage.modifier'
   '"public"': 'storage.modifier'
   '"private"': 'storage.modifier'
@@ -183,6 +182,7 @@ scopes:
   '"final"': 'storage.modifier'
   '"override"': 'storage.modifier'
   '"virtual"': 'storage.modifier'
+  '"noexcept"': 'storage.modifier'
 
   '";"': 'punctuation.terminator.statement'
   '"["': 'punctuation.definition.begin.bracket.square'


### PR DESCRIPTION
### Description of the Change

`noexcept` and `mutable` were added to `storage.modifier` in "tree-sitter-cpp.cson", corresponding with their presence in "c++.cson". `_Atomic`, which is a valid type qualifier in C but not C++, was removed from "tree-sitter-cpp.cson".

### Benefits

`noexcept` and `mutable` will be highlighted correctly, and any confusion caused by `_Atomic` being erroneously highlighted will cease.
